### PR TITLE
Fix: Use app-configured timezone for all date/time operations

### DIFF
--- a/public/basket.php
+++ b/public/basket.php
@@ -42,7 +42,9 @@ $previewEnd   = null;
 $previewError = '';
 
 if ($previewStartRaw && $previewEndRaw) {
+    $utc = new DateTimeZone('UTC');
     try {
+        // Form values are in the app's local timezone
         $startDt = new DateTime($previewStartRaw, $appTz);
         $endDt   = new DateTime($previewEndRaw, $appTz);
     } catch (Throwable $e) {
@@ -55,8 +57,9 @@ if ($previewStartRaw && $previewEndRaw) {
     } elseif ($endDt <= $startDt) {
         $previewError = 'End time must be after start time for availability preview.';
     } else {
-        $previewStart = $startDt->format('Y-m-d H:i:s');
-        $previewEnd   = $endDt->format('Y-m-d H:i:s');
+        // Convert to UTC for DB queries
+        $previewStart = $startDt->setTimezone($utc)->format('Y-m-d H:i:s');
+        $previewEnd   = $endDt->setTimezone($utc)->format('Y-m-d H:i:s');
     }
 }
 

--- a/public/basket_checkout.php
+++ b/public/basket_checkout.php
@@ -21,7 +21,9 @@ if (!$startRaw || !$endRaw) {
     die('Start and end date/time are required.');
 }
 
+// Form values are in the app's local timezone; convert to UTC for DB storage
 $appTz = app_get_timezone();
+$utc   = new DateTimeZone('UTC');
 try {
     $startDt = new DateTime($startRaw, $appTz);
     $endDt   = new DateTime($endRaw, $appTz);
@@ -29,8 +31,8 @@ try {
     die('Invalid date/time.');
 }
 
-$start = $startDt->format('Y-m-d H:i:s');
-$end   = $endDt->format('Y-m-d H:i:s');
+$start = $startDt->setTimezone($utc)->format('Y-m-d H:i:s');
+$end   = $endDt->setTimezone($utc)->format('Y-m-d H:i:s');
 
 if ($end <= $start) {
     die('End time must be after start time.');

--- a/public/book_submit.php
+++ b/public/book_submit.php
@@ -17,19 +17,22 @@ if (!$assetId || !$startRaw || !$endRaw) {
     die('Missing required fields.');
 }
 
-$startTs = strtotime($startRaw);
-$endTs   = strtotime($endRaw);
-
-if ($startTs === false || $endTs === false) {
+// Form values are in the app's local timezone; convert to UTC for DB storage
+$appTz = app_get_timezone();
+$utc   = new DateTimeZone('UTC');
+try {
+    $startDt = new DateTime($startRaw, $appTz);
+    $endDt   = new DateTime($endRaw, $appTz);
+} catch (Throwable $e) {
     die('Invalid date/time.');
 }
 
-$start = date('Y-m-d H:i:s', $startTs);
-$end   = date('Y-m-d H:i:s', $endTs);
-
-if ($end <= $start) {
+if ($endDt <= $startDt) {
     die('End time must be after start time.');
 }
+
+$start = $startDt->setTimezone($utc)->format('Y-m-d H:i:s');
+$end   = $endDt->setTimezone($utc)->format('Y-m-d H:i:s');
 
 // Load asset from Snipe-IT
 try {

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -17,10 +17,6 @@ if (!defined('CONFIG_PATH')) {
 require_once SRC_PATH . '/config_loader.php';
 require_once SRC_PATH . '/datetime_helpers.php';
 
-// Set PHP's default timezone to the app's configured timezone so that
-// all date/time functions (new DateTime(), strtotime(), date(), etc.)
-// use the correct timezone by default.
-$appTz = app_get_timezone();
-if ($appTz) {
-    date_default_timezone_set($appTz->getName());
-}
+// Keep PHP in UTC so all internal dates (DB, comparisons) are UTC.
+// Convert to/from the app's configured timezone only at the UI boundary.
+date_default_timezone_set('UTC');

--- a/src/db.php
+++ b/src/db.php
@@ -38,10 +38,3 @@ try {
     throw new RuntimeException('Could not connect to booking database: ' . $e->getMessage(), 0, $e);
 }
 
-// Align the MySQL session timezone with the app's configured timezone so that
-// CURRENT_TIMESTAMP (used by created_at columns) matches PHP-generated dates.
-$appTz = app_get_timezone();
-if ($appTz) {
-    $offset = (new DateTime('now', $appTz))->format('P'); // e.g. "-05:00"
-    $pdo->exec('SET time_zone = ' . $pdo->quote($offset));
-}


### PR DESCRIPTION
## Summary
- Explicitly sets PHP default timezone to UTC in `bootstrap.php` so all internal dates (DB, comparisons) are UTC.
- All form inputs (`datetime-local`) are parsed as app-local timezone and converted to UTC before DB storage.
- DB values (UTC) are converted to the app's configured timezone when populating form fields for editing.
- Tried/Removed MySQL session timezone override in `db.php` — MySQL should stay UTC, keeping `CURRENT_TIMESTAMP` consistent with PHP-generated dates.
- Replaced `strtotime()`/`date()` calls with timezone-aware `DateTime` objects across all affected files.
- Files updated: `bootstrap.php`, `db.php`, `basket.php`, `basket_checkout.php`, `book_submit.php`, `quick_checkout.php`, `reservation_edit.php`
- Fixes #4

## Test plan
- [x] Verify basket default start time matches current local time
- [x] Verify default end time shows tomorrow at 09:00 local time
- [x] Verify availability alert and form inputs show consistent, correct times
- [x] Confirm `start_datetime`, `end_datetime`, and `created_at` in the database are all stored in UTC
- [x] Verify reservation edit form pre-fills dates in local time correctly
- [x] Verify quick checkout stores dates in UTC