### PR TITLE
Prevent deletion of completed reservations

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -132,6 +132,10 @@ return [
         'block_catalogue_overdue' => true, // block catalogue for users with overdue checkouts
     ],
 
+    'reservations' => [
+        'deletable_statuses' => ['pending', 'confirmed', 'cancelled', 'missed'], // reservation statuses that allow deletion
+    ],
+
     'catalogue' => [
         // Restrict which categories appear in the catalogue filter.
         // Leave empty to show all categories returned by Snipe-IT.

--- a/public/delete_reservation.php
+++ b/public/delete_reservation.php
@@ -26,7 +26,7 @@ if ($resId <= 0) {
 
 // Load reservation to check ownership
 $stmt = $pdo->prepare("
-    SELECT id, user_id
+    SELECT id, user_id, status
     FROM reservations
     WHERE id = :id
     LIMIT 1
@@ -47,6 +47,14 @@ $ownsReservation = $currentUserId !== ''
 if (!$isStaff && !$ownsReservation) {
     http_response_code(403);
     echo 'Access denied.';
+    exit;
+}
+
+$config = load_config();
+$deletableStatuses = $config['reservations']['deletable_statuses'] ?? ['pending', 'confirmed', 'cancelled', 'missed'];
+if (!in_array($reservation['status'] ?? '', $deletableStatuses, true)) {
+    http_response_code(403);
+    echo 'This reservation cannot be deleted.';
     exit;
 }
 

--- a/public/my_bookings.php
+++ b/public/my_bookings.php
@@ -247,6 +247,10 @@ if (!empty($_GET['deleted'])) {
                                         Edit
                                     </a>
                                 <?php endif; ?>
+                                <?php
+                                    $deletableStatuses = (load_config())['reservations']['deletable_statuses'] ?? ['pending', 'confirmed', 'cancelled', 'missed'];
+                                    if (in_array($status, $deletableStatuses, true)):
+                                ?>
                                 <form method="post"
                                       action="delete_reservation.php"
                                       onsubmit="return confirm('Delete this reservation and all its items? This cannot be undone.');">
@@ -255,6 +259,7 @@ if (!empty($_GET['deleted'])) {
                                         Delete reservation
                                     </button>
                                 </form>
+                                <?php endif; ?>
                             </div>
                         </div>
                     </div>

--- a/public/reservation_detail.php
+++ b/public/reservation_detail.php
@@ -143,6 +143,10 @@ $active  = 'staff_reservations.php'; // Treat detail view as part of booking his
             </div>
         <?php endif; ?>
 
+        <?php
+            $deletableStatuses = (load_config())['reservations']['deletable_statuses'] ?? ['pending', 'confirmed', 'cancelled', 'missed'];
+            if (in_array($reservation['status'] ?? '', $deletableStatuses, true)):
+        ?>
         <form method="post"
               action="delete_reservation.php"
               onsubmit="return confirm('Delete this booking and all its items? This cannot be undone.');">
@@ -151,6 +155,7 @@ $active  = 'staff_reservations.php'; // Treat detail view as part of booking his
                 Delete this booking
             </button>
         </form>
+        <?php endif; ?>
 
     </div>
 </div>

--- a/public/staff_reservations.php
+++ b/public/staff_reservations.php
@@ -505,6 +505,10 @@ try {
                                                 </button>
                                             </form>
                                         <?php endif; ?>
+                                        <?php
+                                            $deletableStatuses = (load_config())['reservations']['deletable_statuses'] ?? ['pending', 'confirmed', 'cancelled', 'missed'];
+                                            if (in_array($status, $deletableStatuses, true)):
+                                        ?>
                                         <form method="post"
                                               action="delete_reservation.php"
                                               onsubmit="return confirm('Delete this reservation and all its items? This cannot be undone.');">
@@ -515,6 +519,7 @@ try {
                                                 Delete
                                             </button>
                                         </form>
+                                        <?php endif; ?>
                                     </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
## Summary
- Adds `reservations.deletable_statuses` config array to control which reservation statuses allow deletion.
- Defaults to `['pending', 'confirmed', 'cancelled', 'missed']`, excluding `completed` (checked-out reservations).
- Backend guard in `delete_reservation.php` returns 403 for non-deletable statuses.
- Delete button hidden in `my_bookings.php`, `staff_reservations.php`, and `reservation_detail.php` for non-deletable statuses.
- Configurable: admins can adjust the list in `config.php` under the new `reservations` section.
- Fixes #2

## Test plan
- [x] Verify completed reservations no longer show a delete button in my_bookings
- [x] Verify completed reservations no longer show a delete button in staff_reservations
- [x] Verify direct POST to `delete_reservation.php` with a completed reservation returns 403
- [x] Verify pending/confirmed/missed/cancelled reservations can still be deleted
- [x] Verify adding `completed` to `deletable_statuses` in config re-enables deletion