### PR TITLE
Add note to asset history for non-checked-out assets (fixes #9)

### DIFF
--- a/src/snipeit_client.php
+++ b/src/snipeit_client.php
@@ -831,6 +831,41 @@ function checkin_asset(int $assetId, string $note = ''): void
 }
 
 /**
+ * Add a note to an asset's activity log in Snipe-IT.
+ *
+ * @param int    $assetId
+ * @param string $note
+ * @return void
+ * @throws Exception
+ */
+function add_asset_note(int $assetId, string $note): void
+{
+    if ($assetId <= 0) {
+        throw new InvalidArgumentException('Invalid asset ID for note.');
+    }
+    if ($note === '') {
+        throw new InvalidArgumentException('Note text cannot be empty.');
+    }
+
+    $resp = snipeit_request('POST', 'notes/' . $assetId . '/store', ['note' => $note]);
+
+    $status = $resp['status'] ?? 'success';
+    if ($status !== 'success') {
+        $message = $resp['messages'] ?? ($resp['message'] ?? 'Unknown API response');
+        if (is_array($message)) {
+            $flat = [];
+            array_walk_recursive($message, function ($val) use (&$flat) {
+                if (is_string($val) && trim($val) !== '') {
+                    $flat[] = $val;
+                }
+            });
+            $message = $flat ? implode('; ', $flat) : 'Unknown API response';
+        }
+        throw new Exception('Snipe-IT add note did not succeed: ' . $message);
+    }
+}
+
+/**
  * Fetch checked-out assets (requestable only) directly from Snipe-IT.
  *
  * @param bool $overdueOnly


### PR DESCRIPTION
## Summary
- When staff scan an asset that isn't currently checked out during quick check-in, the system now adds a note to the asset's Snipe-IT activity log instead of failing with an error
- Checked-out assets continue to check in normally via the existing flow
- Added add_asset_note() function in src/snipeit_client.php using the Snipe-IT Notes API (POST /notes/{id}/store)
- Added a Not checked out warning badge in the quick check-in asset list so staff can see which assets will get a note vs a check-in before submitting

## Test plan
- [x] Add a checked-out asset to quick check-in — should check in normally
- [x] Add a not-checked-out asset — should show Not checked out badge in the list
- [x] Submit with a not-checked-out asset — should succeed with a note added to asset history in Snipe-IT
- [x] Verify the note appears in the asset activity log in Snipe-IT admin
- [x] Submit a mix of both types — checked-out assets check in, not-checked-out assets get notes