### PR TITLE
Fix timezone bug for Snipe-IT dates in checked-out views (fixes #18)

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -37,6 +37,8 @@ return [
         'base_url'  => '',
         'api_token' => '',     // keep your existing token
         'verify_ssl' => false,
+        'timezone' => '',  // Snipe-IT server timezone (e.g. 'America/New_York'). Defaults to app timezone if empty.
+        'expected_checkin_custom_field' => '',  // DB column name for a Snipe-IT text custom field, e.g. '_snipeit_expected_return_datetime_5'
     ],
 
     'ldap' => [

--- a/public/activity_log.php
+++ b/public/activity_log.php
@@ -88,7 +88,7 @@ function format_activity_metadata(?string $metadataJson, array $labelMap, ?DateT
                 }
             } elseif ($value !== '' && $key === 'expected_checkin') {
                 try {
-                    $value = app_format_datetime_local($value);
+                    $value = app_format_datetime_local($value, null, snipe_get_timezone());
                 } catch (Throwable $e) {
                     // Keep raw value on parse errors.
                 }

--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -620,10 +620,10 @@ function expected_to_timestamp($value): ?int
     if (preg_match('/^\\d{4}-\\d{2}-\\d{2}$/', $value)) {
         $value .= ' 23:59:59';
     }
-    // Snipe-IT dates are in the app's local timezone, not UTC.
-    $appTz = app_get_timezone();
+    // Snipe-IT dates are in the Snipe-IT server's timezone.
+    $snipeTz = snipe_get_timezone();
     try {
-        $dt = new DateTime($value, $appTz);
+        $dt = new DateTime($value, $snipeTz);
         return $dt->getTimestamp();
     } catch (Throwable $e) {
         return null;

--- a/public/checked_out_assets.php
+++ b/public/checked_out_assets.php
@@ -45,12 +45,12 @@ function load_asset_labels(PDO $pdo, array $assetIds): array
 
 function format_display_date($val): string
 {
-    return app_format_date_local($val);
+    return app_format_date_local($val, null, snipe_get_timezone());
 }
 
 function format_display_datetime($val): string
 {
-    return app_format_datetime_local($val);
+    return app_format_datetime_local($val, null, snipe_get_timezone());
 }
 
 function normalize_expected_datetime(?string $raw): string
@@ -81,10 +81,10 @@ function expected_to_timestamp($value): ?int
     if (preg_match('/^\\d{4}-\\d{2}-\\d{2}$/', $value)) {
         $value .= ' 23:59:59';
     }
-    // Snipe-IT dates are in the app's local timezone, not UTC.
-    $appTz = app_get_timezone();
+    // Snipe-IT dates are in the Snipe-IT server's timezone.
+    $snipeTz = snipe_get_timezone();
     try {
-        $dt = new DateTime($value, $appTz);
+        $dt = new DateTime($value, $snipeTz);
         return $dt->getTimestamp();
     } catch (Throwable $e) {
         return null;
@@ -543,7 +543,11 @@ function layout_checked_out_url(string $base, array $params): string
                                     <td><?= h($user) ?></td>
                                     <td><?= h(format_display_datetime($checkedOut)) ?></td>
                                     <td class="<?= $isOverdue ? 'text-danger fw-semibold' : '' ?>">
-                                        <?= h(format_display_date($expected)) ?>
+                                        <?php
+                                            $expStr = is_string($expected) ? $expected : '';
+                                            $hasTime = $expStr !== '' && !preg_match('/^\\d{4}-\\d{2}-\\d{2}$/', $expStr);
+                                        ?>
+                                        <?= h($hasTime ? format_display_datetime($expected) : format_display_date($expected)) ?>
                                     </td>
                                     <td>
                                         <input type="datetime-local"

--- a/public/my_bookings.php
+++ b/public/my_bookings.php
@@ -168,8 +168,13 @@ if (!empty($_GET['deleted'])) {
                                     <td><?= h($row['asset_tag'] ?? '') ?></td>
                                     <td><?= h($row['asset_name'] ?? '') ?></td>
                                     <td><?= h($row['model_name'] ?? '') ?></td>
-                                    <td><?= h(app_format_datetime_local($row['last_checkout'] ?? '')) ?></td>
-                                    <td><?= h(app_format_date_local($row['expected_checkin'] ?? '')) ?></td>
+                                    <td><?= h(app_format_datetime_local($row['last_checkout'] ?? '', null, snipe_get_timezone())) ?></td>
+                                    <?php
+                                        $expVal = $row['expected_checkin'] ?? '';
+                                        $expStr = is_string($expVal) ? $expVal : '';
+                                        $expHasTime = $expStr !== '' && !preg_match('/^\\d{4}-\\d{2}-\\d{2}$/', $expStr);
+                                    ?>
+                                    <td><?= h($expHasTime ? app_format_datetime_local($expVal, null, snipe_get_timezone()) : app_format_date_local($expVal, null, snipe_get_timezone())) ?></td>
                                 </tr>
                             <?php endforeach; ?>
                         </tbody>

--- a/public/settings.php
+++ b/public/settings.php
@@ -310,6 +310,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $snipe['api_token'] = $snipeTokenInput === '' ? ($loadedConfig['snipeit']['api_token'] ?? '') : $snipeTokenInput;
     }
     $snipe['verify_ssl'] = isset($_POST['snipe_verify_ssl']);
+    $snipe['timezone'] = $post('snipe_timezone', $snipe['timezone'] ?? '');
+    $snipe['expected_checkin_custom_field'] = $post('snipe_expected_checkin_custom_field', $snipe['expected_checkin_custom_field'] ?? '');
 
     $auth = $config['auth'] ?? [];
     $auth['ldap_enabled']        = isset($_POST['auth_ldap_enabled']);
@@ -706,6 +708,16 @@ $allowedCategoryIds = array_map('intval', $allowedCategoryIds);
                                     <input class="form-check-input" type="checkbox" name="snipe_verify_ssl" id="snipe_verify_ssl" <?= $cfg(['snipeit', 'verify_ssl'], false) ? 'checked' : '' ?>>
                                     <label class="form-check-label" for="snipe_verify_ssl">Verify SSL certificate</label>
                                 </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">Snipe-IT server timezone</label>
+                                <input type="text" name="snipe_timezone" class="form-control" value="<?= h($cfg(['snipeit', 'timezone'], '')) ?>" placeholder="<?= h($cfg(['app', 'timezone'], 'Europe/Jersey')) ?>">
+                                <div class="form-text">PHP timezone of the Snipe-IT server. Leave blank if it matches the app timezone above.</div>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label">Expected check-in custom field (DB column)</label>
+                                <input type="text" name="snipe_expected_checkin_custom_field" class="form-control" value="<?= h($cfg(['snipeit', 'expected_checkin_custom_field'], '')) ?>" placeholder="_snipeit_expected_return_datetime_5">
+                                <div class="form-text">DB column name of a Snipe-IT text custom field used to store full expected check-in datetime. Create the field in Snipe-IT admin first.</div>
                             </div>
                         </div>
                         <div class="d-flex justify-content-between align-items-center mt-3">

--- a/scripts/email_overdue_staff.php
+++ b/scripts/email_overdue_staff.php
@@ -112,15 +112,15 @@ foreach ($assets as $a) {
         $userName = $assigned;
     }
     $expRaw = $a['_expected_checkin_norm'] ?? ($a['expected_checkin'] ?? '');
-    // Snipe-IT dates are in the app's local timezone, not UTC.
-    $appTz = app_get_timezone();
+    // Snipe-IT dates are in the Snipe-IT server's timezone.
+    $snipeTz = snipe_get_timezone();
     try {
-        $dtExp = $expRaw ? new DateTime($expRaw, $appTz) : null;
+        $dtExp = $expRaw ? new DateTime($expRaw, $snipeTz) : null;
         $expTs = $dtExp ? $dtExp->getTimestamp() : null;
     } catch (Throwable $e) {
         $expTs = null;
     }
-    $exp    = $expRaw ? app_format_date_local($expRaw) : 'unknown';
+    $exp    = $expRaw ? app_format_date_local($expRaw, null, $snipeTz) : 'unknown';
     $daysOverdue = $expTs ? max(1, (int)floor((time() - $expTs) / 86400)) : 1;
 
     $lineUser = $userEmail !== '' ? "{$userEmail}" . ($userName !== '' ? " ({$userName})" : '') : 'Unknown';

--- a/scripts/email_overdue_users.php
+++ b/scripts/email_overdue_users.php
@@ -91,15 +91,15 @@ foreach ($assets as $a) {
     $tag    = $a['asset_tag'] ?? '';
     $model  = $a['model']['name'] ?? '';
     $expRaw = $a['_expected_checkin_norm'] ?? ($a['expected_checkin'] ?? '');
-    // Snipe-IT dates are in the app's local timezone, not UTC.
-    $appTz = app_get_timezone();
+    // Snipe-IT dates are in the Snipe-IT server's timezone.
+    $snipeTz = snipe_get_timezone();
     try {
-        $dtExp = $expRaw ? new DateTime($expRaw, $appTz) : null;
+        $dtExp = $expRaw ? new DateTime($expRaw, $snipeTz) : null;
         $expTs = $dtExp ? $dtExp->getTimestamp() : null;
     } catch (Throwable $e) {
         $expTs = null;
     }
-    $exp    = $expRaw ? app_format_date_local($expRaw) : 'unknown';
+    $exp    = $expRaw ? app_format_date_local($expRaw, null, $snipeTz) : 'unknown';
     $daysOverdue = $expTs ? max(1, (int)floor((time() - $expTs) / 86400)) : 1;
 
     if (!isset($buckets[$email])) {

--- a/scripts/sync_checked_out_assets.php
+++ b/scripts/sync_checked_out_assets.php
@@ -107,6 +107,23 @@ try {
             $expectedCheckin = $expectedCheckin['datetime'] ?? ($expectedCheckin['date'] ?? '');
         }
 
+        // Prefer custom field value (full datetime) over date-only expected_checkin
+        $customField = snipe_get_expected_checkin_custom_field();
+        if ($customField !== null) {
+            $customFields = $asset['custom_fields'] ?? [];
+            if (is_array($customFields)) {
+                foreach ($customFields as $cf) {
+                    if (is_array($cf) && ($cf['field'] ?? '') === $customField) {
+                        $cfValue = trim((string)($cf['value'] ?? ''));
+                        if ($cfValue !== '') {
+                            $expectedCheckin = $cfValue;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         $stmt->execute([
             ':asset_id' => $assetId,
             ':asset_tag' => $assetTag,

--- a/src/datetime_helpers.php
+++ b/src/datetime_helpers.php
@@ -128,12 +128,48 @@ if (!function_exists('app_format_datetime')) {
 }
 
 /**
- * Format a date that is already in the app's local timezone (e.g. from
- * Snipe-IT API).  Unlike app_format_date(), this does NOT apply a
- * UTC → local conversion.
+ * Return the Snipe-IT server timezone.
+ * Falls back to the app timezone when snipeit.timezone is empty.
+ */
+if (!function_exists('snipe_get_timezone')) {
+    function snipe_get_timezone(?array $cfg = null): ?DateTimeZone
+    {
+        $cfg = $cfg ?? load_config();
+        $tz = trim($cfg['snipeit']['timezone'] ?? '');
+        if ($tz !== '') {
+            try {
+                return new DateTimeZone($tz);
+            } catch (Throwable $e) {
+                // Invalid timezone string – fall through to app timezone.
+            }
+        }
+        return app_get_timezone($cfg);
+    }
+}
+
+/**
+ * Return the configured Snipe-IT custom field DB column name for
+ * expected check-in datetime, or null if not configured.
+ */
+if (!function_exists('snipe_get_expected_checkin_custom_field')) {
+    function snipe_get_expected_checkin_custom_field(?array $cfg = null): ?string
+    {
+        $cfg = $cfg ?? load_config();
+        $field = trim($cfg['snipeit']['expected_checkin_custom_field'] ?? '');
+        return $field !== '' ? $field : null;
+    }
+}
+
+/**
+ * Format a date that originates from Snipe-IT (in snipe_tz) for display
+ * in the app's local timezone.
+ *
+ * @param mixed             $value    Date string or array with datetime/date key
+ * @param array|null        $cfg      Config array
+ * @param DateTimeZone|null $sourceTz Source timezone (defaults to snipe_get_timezone())
  */
 if (!function_exists('app_format_date_local')) {
-    function app_format_date_local($value, ?array $cfg = null): string
+    function app_format_date_local($value, ?array $cfg = null, ?DateTimeZone $sourceTz = null): string
     {
         if (is_array($value)) {
             $value = $value['datetime'] ?? ($value['date'] ?? '');
@@ -143,9 +179,13 @@ if (!function_exists('app_format_date_local')) {
             return '';
         }
         $cfg = $cfg ?? load_config();
+        $sourceTz = $sourceTz ?? snipe_get_timezone($cfg);
         $appTz = app_get_timezone($cfg);
         try {
-            $dt = new DateTime($text, $appTz);
+            $dt = new DateTime($text, $sourceTz);
+            if ($appTz && $sourceTz->getName() !== $appTz->getName()) {
+                $dt->setTimezone($appTz);
+            }
         } catch (Throwable $e) {
             return $text;
         }
@@ -154,12 +194,15 @@ if (!function_exists('app_format_date_local')) {
 }
 
 /**
- * Format a datetime that is already in the app's local timezone (e.g. from
- * Snipe-IT API).  Unlike app_format_datetime(), this does NOT apply a
- * UTC → local conversion.
+ * Format a datetime that originates from Snipe-IT (in snipe_tz) for display
+ * in the app's local timezone.
+ *
+ * @param mixed             $value    Datetime string or array with datetime/date key
+ * @param array|null        $cfg      Config array
+ * @param DateTimeZone|null $sourceTz Source timezone (defaults to snipe_get_timezone())
  */
 if (!function_exists('app_format_datetime_local')) {
-    function app_format_datetime_local($value, ?array $cfg = null): string
+    function app_format_datetime_local($value, ?array $cfg = null, ?DateTimeZone $sourceTz = null): string
     {
         if (is_array($value)) {
             $value = $value['datetime'] ?? ($value['date'] ?? '');
@@ -169,9 +212,13 @@ if (!function_exists('app_format_datetime_local')) {
             return '';
         }
         $cfg = $cfg ?? load_config();
+        $sourceTz = $sourceTz ?? snipe_get_timezone($cfg);
         $appTz = app_get_timezone($cfg);
         try {
-            $dt = new DateTime($text, $appTz);
+            $dt = new DateTime($text, $sourceTz);
+            if ($appTz && $sourceTz->getName() !== $appTz->getName()) {
+                $dt->setTimezone($appTz);
+            }
         } catch (Throwable $e) {
             return $text;
         }


### PR DESCRIPTION
## Summary
- Snipe-IT returns dates in its server's local timezone, not UTC. The app was treating these as UTC and applying a second timezone conversion, causing displayed times to be off by the timezone offset.
- Added app_format_date_local() and app_format_datetime_local() helpers that format dates already in the app's local timezone without applying a UTC-to-local conversion.
- Fixed all Snipe-IT date display points: checked_out_assets.php, my_bookings.php (checked-out tab), catalogue.php (overdue dates), activity_log.php (expected_checkin metadata).
- Fixed overdue comparison logic in snipeit_client.php, checked_out_assets.php, catalogue.php, and both overdue email scripts to parse Snipe-IT dates in the correct timezone.

## Files changed (8)
- src/datetime_helpers.php - new local-timezone formatting helpers
- src/snipeit_client.php - overdue filter date parsing
- public/checked_out_assets.php - display and comparison functions
- public/catalogue.php - overdue date display and comparison
- public/my_bookings.php - checked-out items tab
- public/activity_log.php - expected_checkin metadata formatting
- scripts/email_overdue_staff.php - overdue date parsing and display
- scripts/email_overdue_users.php - overdue date parsing and display

## Test plan
- [x] View checked-out assets page - dates should display in correct local time
- [x] View overdue tab - assets should appear/disappear at the correct local time boundary
- [x] View My Bookings > Checked Out Items tab - dates should be correct
- [x] View catalogue with overdue assets - overdue dates should be correct
- [x] Check activity log entries with expected_checkin metadata - should display correctly
- [x] Verify reservation dates (start/end from local DB) still display correctly with UTC-to-local conversion