### PR TITLE
Flag broken/missing assets with warnings and block checkout

### DIFF
--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -1287,6 +1287,16 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                                             <?= label_safe($notes) ?>
                                         </div>
                                     <?php endif; ?>
+                                    <?php
+                                        $undeployInfo = count_undeployable_assets_by_model($modelId);
+                                        if ($undeployInfo['undeployable_count'] > 0):
+                                            $uCount = $undeployInfo['undeployable_count'];
+                                            $uStatuses = implode(', ', $undeployInfo['status_names']);
+                                    ?>
+                                        <div class="mt-2">
+                                            <span class="badge bg-danger" title="<?= h($uStatuses) ?>"><?= $uCount ?> unit<?= $uCount !== 1 ? 's' : '' ?> under repair</span>
+                                        </div>
+                                    <?php endif; ?>
                                 </p>
 
                                 <form method="post"

--- a/public/staff_checkout.php
+++ b/public/staff_checkout.php
@@ -291,6 +291,9 @@ if ($selectedReservationId) {
                         if (strpos($status, 'checked out') !== false) {
                             continue;
                         }
+                        if (!is_asset_deployable($a)) {
+                            continue;
+                        }
                         $filtered[] = $a;
                     }
                     $modelAssets[$mid] = $filtered;
@@ -475,6 +478,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
                 if (!$isRequestable) {
                     throw new Exception('This asset is not requestable in Snipe-IT.');
+                }
+                if (!is_asset_deployable($asset)) {
+                    $statusName = $asset['status_label']['name'] ?? 'undeployable';
+                    throw new Exception('This asset is currently flagged as "' . $statusName . '" and cannot be checked out.');
                 }
 
                 // Enforce that the asset's model is in the selected reservation and within quantity.


### PR DESCRIPTION
## Summary
- Add warning badges on catalogue cards when a model has undeployable (broken/missing/etc.) assets, showing units under repair count
- Show non-blocking warnings in the basket when selected models have undeployable assets
- Filter undeployable assets from the staff checkout dropdown so they cannot be selected
- Block scanning undeployable asset tags during staff checkout with a clear error message

Closes #6

## Changes
- `src/snipeit_client.php` — New `is_asset_deployable()` and `count_undeployable_assets_by_model()` helpers
- `public/catalogue.php` — Red badge on model cards for undeployable asset count
- `public/basket.php` — alert-warning for models with undeployable assets (does not block checkout)
- `public/staff_checkout.php` — Filter + scan validation for undeployable assets

## Test plan
- [ ] Set an asset status to Broken (undeployable) in Snipe-IT while keeping it requestable
- [ ] Catalogue: model card shows units under repair badge
- [ ] Basket: adding that model shows a warning but does not block checkout
- [ ] Staff checkout: broken asset does not appear in available assets dropdown
- [ ] Staff checkout: scanning a broken asset tag shows an error message
- [ ] Models with all-deployable assets show no warnings anywhere