### PR TITLE
Fix #32: Convert active-checkout block to warning, show related checkouts

### DIFF
--- a/public/basket_checkout.php
+++ b/public/basket_checkout.php
@@ -61,11 +61,6 @@ if ($snipeUserId > 0 && !check_user_has_access_group($snipeUserId)) {
     basket_error('You do not have access to reserve equipment. Please contact an administrator to be assigned an Access group.');
 }
 
-// Single active checkout
-if ($clCfg['enabled'] && $clCfg['single_active_checkout'] && $snipeUserId > 0 && check_user_has_active_checkout($snipeUserId)) {
-    basket_error('You already have assets checked out. Please return them before making a new reservation. (Single active checkout is enforced.)');
-}
-
 // Duration limit
 if ($clCfg['enabled'] && $snipeUserId > 0) {
     $durationErr = validate_checkout_duration($snipeUserId, $startDt, $endDt);

--- a/public/reservation_detail.php
+++ b/public/reservation_detail.php
@@ -144,8 +144,10 @@ $active  = 'staff_reservations.php'; // Treat detail view as part of booking his
         <?php endif; ?>
 
         <?php
-            // Show linked checkouts if reservation is fulfilled
-            $linkedCheckouts = get_checkouts_for_reservation($pdo, $id);
+            // Show linked checkouts and related family checkouts
+            $checkoutFamily = get_checkout_family_for_reservation($pdo, $id);
+            $linkedCheckouts = $checkoutFamily['direct'];
+            $relatedCheckouts = $checkoutFamily['related'];
             if (!empty($linkedCheckouts)):
         ?>
         <h5>Checkouts</h5>
@@ -180,6 +182,54 @@ $active  = 'staff_reservations.php'; // Treat detail view as part of booking his
                                             <td><?= h($ci['model_name'] ?? '') ?></td>
                                             <td><?= h(display_datetime($ci['checked_out_at'] ?? '')) ?></td>
                                             <td><?= $ci['checked_in_at'] ? h(display_datetime($ci['checked_in_at'])) : '<span class="badge bg-warning text-dark">Out</span>' ?></td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php endforeach; ?>
+        <?php endif; ?>
+
+        <?php if (!empty($relatedCheckouts)): ?>
+        <h5>Related checkouts</h5>
+        <p class="text-muted small">Checkouts linked via the same parent/child chain but belonging to other bookings.</p>
+        <?php foreach ($relatedCheckouts as $rco): ?>
+            <div class="card mb-3 border-secondary">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <strong>Checkout #<?= (int)$rco['id'] ?></strong>
+                        <?= layout_checkout_status_badge($rco['status'] ?? '') ?>
+                    </div>
+                    <div class="small text-muted mb-2">
+                        <?= h(display_datetime($rco['start_datetime'] ?? '')) ?> &rarr; <?= h(display_datetime($rco['end_datetime'] ?? '')) ?>
+                        <?php if (!empty($rco['reservation_id'])): ?>
+                            &middot; <a href="reservation_detail.php?id=<?= (int)$rco['reservation_id'] ?>">Booking #<?= (int)$rco['reservation_id'] ?></a>
+                        <?php endif; ?>
+                    </div>
+                    <?php $rcoItems = get_checkout_items($pdo, (int)$rco['id']); ?>
+                    <?php if (!empty($rcoItems)): ?>
+                        <div class="table-responsive">
+                            <table class="table table-sm table-striped align-middle mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Asset Tag</th>
+                                        <th>Name</th>
+                                        <th>Model</th>
+                                        <th>Checked Out</th>
+                                        <th>Returned</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($rcoItems as $rci): ?>
+                                        <tr class="<?= $rci['checked_in_at'] ? 'table-success' : '' ?>">
+                                            <td><?= h($rci['asset_tag'] ?? '') ?></td>
+                                            <td><?= h($rci['asset_name'] ?? '') ?></td>
+                                            <td><?= h($rci['model_name'] ?? '') ?></td>
+                                            <td><?= h(display_datetime($rci['checked_out_at'] ?? '')) ?></td>
+                                            <td><?= $rci['checked_in_at'] ? h(display_datetime($rci['checked_in_at'])) : '<span class="badge bg-warning text-dark">Out</span>' ?></td>
                                         </tr>
                                     <?php endforeach; ?>
                                 </tbody>


### PR DESCRIPTION
## Summary
- **basket.php**: Replace blocking error for active checkout with a non-blocking amber warning that shows the expected return date and explains items will be appended
- **basket_checkout.php**: Remove the duplicate blocking check — the warning on basket.php is sufficient
- **booking_helpers.php**: Add `get_checkout_family_for_reservation()` to walk the parent/child checkout chain
- **reservation_detail.php**: Show "Related checkouts" section with `border-secondary` cards linking to their parent bookings

## Test plan
- [x] As a user with an active checkout, visit basket.php — amber warning with return date, submit button enabled
- [x] Confirm booking — reservation created successfully
- [x] View a reservation with appended checkout — "Related checkouts" section visible with link to parent booking

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)