### PR TITLE
Fix #36: Add opening hours management

### DIFF
--- a/public/activity_log.php
+++ b/public/activity_log.php
@@ -253,6 +253,9 @@ try {
             <li class="nav-item">
                 <a class="nav-link" href="settings.php">Settings</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link" href="opening_hours.php">Opening Hours</a>
+            </li>
         </ul>
 
         <div class="card">

--- a/public/basket.php
+++ b/public/basket.php
@@ -218,6 +218,18 @@ if (!empty($basket) && $snipeUserId > 0) {
     }
 }
 
+// Opening hours enforcement (end users only)
+if (!empty($basket) && $previewStart && $previewEnd) {
+    require_once SRC_PATH . '/opening_hours.php';
+    $ohErrors = oh_validate_reservation_window(
+        new DateTime($previewStart, new DateTimeZone('UTC')),
+        new DateTime($previewEnd, new DateTimeZone('UTC'))
+    );
+    foreach ($ohErrors as $ohe) {
+        $checkoutErrors[] = $ohe;
+    }
+}
+
 $hasCheckoutErrors = !empty($checkoutErrors);
 
 // Non-blocking warnings

--- a/public/basket_checkout.php
+++ b/public/basket_checkout.php
@@ -88,6 +88,13 @@ if ($snipeUserId > 0) {
     }
 }
 
+// Opening hours enforcement (end users only)
+require_once SRC_PATH . '/opening_hours.php';
+$ohErrors = oh_validate_reservation_window($startDt, $endDt);
+if (!empty($ohErrors)) {
+    basket_error($ohErrors[0]);
+}
+
 $pdo->beginTransaction();
 
 try {

--- a/public/install/schema.sql
+++ b/public/install/schema.sql
@@ -186,3 +186,77 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 INSERT IGNORE INTO schema_version (version)
 VALUES ('v1.1.0');
+
+-- ------------------------------------------------------
+-- Opening hours: default weekly schedule
+-- ------------------------------------------------------
+CREATE TABLE IF NOT EXISTS opening_hours_default (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    day_of_week TINYINT UNSIGNED NOT NULL,
+    is_closed TINYINT(1) NOT NULL DEFAULT 0,
+    open_time TIME DEFAULT NULL,
+    close_time TIME DEFAULT NULL,
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_oh_default_day (day_of_week)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT IGNORE INTO opening_hours_default (day_of_week, is_closed, open_time, close_time) VALUES
+    (1, 0, '09:00:00', '17:00:00'),
+    (2, 0, '09:00:00', '17:00:00'),
+    (3, 0, '09:00:00', '17:00:00'),
+    (4, 0, '09:00:00', '17:00:00'),
+    (5, 0, '09:00:00', '17:00:00'),
+    (6, 1, NULL, NULL),
+    (7, 1, NULL, NULL);
+
+-- ------------------------------------------------------
+-- Opening hours: recurring schedule override periods
+-- ------------------------------------------------------
+CREATE TABLE IF NOT EXISTS opening_hours_schedules (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    KEY idx_oh_schedules_dates (start_date, end_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ------------------------------------------------------
+-- Opening hours: day rows per schedule
+-- ------------------------------------------------------
+CREATE TABLE IF NOT EXISTS opening_hours_schedule_days (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    schedule_id INT UNSIGNED NOT NULL,
+    day_of_week TINYINT UNSIGNED NOT NULL,
+    is_closed TINYINT(1) NOT NULL DEFAULT 0,
+    open_time TIME DEFAULT NULL,
+    close_time TIME DEFAULT NULL,
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_oh_schedule_day (schedule_id, day_of_week),
+    CONSTRAINT fk_oh_schedule_days_schedule
+        FOREIGN KEY (schedule_id)
+        REFERENCES opening_hours_schedules (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ------------------------------------------------------
+-- Opening hours: one-off datetime overrides
+-- ------------------------------------------------------
+CREATE TABLE IF NOT EXISTS opening_hours_overrides (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    label VARCHAR(255) NOT NULL DEFAULT '',
+    start_datetime DATETIME NOT NULL,
+    end_datetime DATETIME NOT NULL,
+    override_type ENUM('open','closed') NOT NULL DEFAULT 'closed',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    KEY idx_oh_overrides_dates (start_datetime, end_datetime)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT IGNORE INTO schema_version (version)
+VALUES ('v1.2.0');

--- a/public/install/upgrade/v1.2.0.sql
+++ b/public/install/upgrade/v1.2.0.sql
@@ -1,0 +1,84 @@
+-- Upgrade v1.2.0: Opening Hours
+--
+-- New tables: opening_hours_default, opening_hours_schedules,
+--             opening_hours_schedule_days, opening_hours_overrides
+
+-- -------------------------------------------------------
+-- 1. Default weekly hours (7 rows, one per weekday)
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS opening_hours_default (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    day_of_week TINYINT UNSIGNED NOT NULL,
+    is_closed TINYINT(1) NOT NULL DEFAULT 0,
+    open_time TIME DEFAULT NULL,
+    close_time TIME DEFAULT NULL,
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_oh_default_day (day_of_week)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- -------------------------------------------------------
+-- 2. Recurring schedule override periods
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS opening_hours_schedules (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    KEY idx_oh_schedules_dates (start_date, end_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- -------------------------------------------------------
+-- 3. Day rows per schedule
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS opening_hours_schedule_days (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    schedule_id INT UNSIGNED NOT NULL,
+    day_of_week TINYINT UNSIGNED NOT NULL,
+    is_closed TINYINT(1) NOT NULL DEFAULT 0,
+    open_time TIME DEFAULT NULL,
+    close_time TIME DEFAULT NULL,
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_oh_schedule_day (schedule_id, day_of_week),
+    CONSTRAINT fk_oh_schedule_days_schedule
+        FOREIGN KEY (schedule_id)
+        REFERENCES opening_hours_schedules (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- -------------------------------------------------------
+-- 4. One-off datetime overrides
+-- -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS opening_hours_overrides (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    label VARCHAR(255) NOT NULL DEFAULT '',
+    start_datetime DATETIME NOT NULL,
+    end_datetime DATETIME NOT NULL,
+    override_type ENUM('open','closed') NOT NULL DEFAULT 'closed',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    KEY idx_oh_overrides_dates (start_datetime, end_datetime)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- -------------------------------------------------------
+-- 5. Seed default hours: Mon-Fri 09:00-17:00, Sat-Sun closed
+-- -------------------------------------------------------
+INSERT IGNORE INTO opening_hours_default (day_of_week, is_closed, open_time, close_time) VALUES
+    (1, 0, '09:00:00', '17:00:00'),
+    (2, 0, '09:00:00', '17:00:00'),
+    (3, 0, '09:00:00', '17:00:00'),
+    (4, 0, '09:00:00', '17:00:00'),
+    (5, 0, '09:00:00', '17:00:00'),
+    (6, 1, NULL, NULL),
+    (7, 1, NULL, NULL);
+
+-- -------------------------------------------------------
+-- 6. Record schema version
+-- -------------------------------------------------------
+INSERT IGNORE INTO schema_version (version)
+VALUES ('v1.2.0');

--- a/public/opening_hours.php
+++ b/public/opening_hours.php
@@ -1,0 +1,577 @@
+<?php
+require_once __DIR__ . '/../src/bootstrap.php';
+require_once SRC_PATH . '/auth.php';
+require_once SRC_PATH . '/layout.php';
+require_once SRC_PATH . '/db.php';
+require_once SRC_PATH . '/opening_hours.php';
+
+$active  = basename($_SERVER['PHP_SELF']);
+$isAdmin = !empty($currentUser['is_admin']);
+$isStaff = !empty($currentUser['is_staff']) || $isAdmin;
+
+if (!$isAdmin) {
+    http_response_code(403);
+    echo 'Access denied.';
+    exit;
+}
+
+$config = load_config();
+$appTz  = app_get_timezone();
+
+$dayNames = [1 => 'Monday', 2 => 'Tuesday', 3 => 'Wednesday', 4 => 'Thursday', 5 => 'Friday', 6 => 'Saturday', 7 => 'Sunday'];
+
+// -------------------------------------------------------
+// Handle POST actions
+// -------------------------------------------------------
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    // --- Default schedule ---
+    if ($action === 'save_default') {
+        $days = [];
+        for ($d = 1; $d <= 7; $d++) {
+            $closed = isset($_POST['default_closed_' . $d]);
+            $days[$d] = [
+                'is_closed' => $closed,
+                'open_time' => $closed ? null : ($_POST['default_open_' . $d] ?? null),
+                'close_time' => $closed ? null : ($_POST['default_close_' . $d] ?? null),
+            ];
+        }
+        oh_save_default_schedule($days);
+        $_SESSION['oh_message'] = 'Default weekly hours saved.';
+        header('Location: opening_hours.php');
+        exit;
+    }
+
+    // --- Create schedule override ---
+    if ($action === 'create_schedule') {
+        $name = trim($_POST['sched_name'] ?? '');
+        $startDate = trim($_POST['sched_start'] ?? '');
+        $endDate = trim($_POST['sched_end'] ?? '');
+        if ($name === '' || $startDate === '' || $endDate === '') {
+            $_SESSION['oh_error'] = 'Name, start date and end date are required.';
+            header('Location: opening_hours.php');
+            exit;
+        }
+        $days = [];
+        for ($d = 1; $d <= 7; $d++) {
+            $closed = isset($_POST['sched_closed_' . $d]);
+            $days[$d] = [
+                'is_closed' => $closed,
+                'open_time' => $closed ? null : ($_POST['sched_open_' . $d] ?? null),
+                'close_time' => $closed ? null : ($_POST['sched_close_' . $d] ?? null),
+            ];
+        }
+        oh_create_schedule($name, $startDate, $endDate, $days);
+        $_SESSION['oh_message'] = 'Schedule override created.';
+        header('Location: opening_hours.php');
+        exit;
+    }
+
+    // --- Update schedule override ---
+    if ($action === 'update_schedule') {
+        $id = (int)($_POST['sched_id'] ?? 0);
+        $name = trim($_POST['sched_name'] ?? '');
+        $startDate = trim($_POST['sched_start'] ?? '');
+        $endDate = trim($_POST['sched_end'] ?? '');
+        if ($id <= 0 || $name === '' || $startDate === '' || $endDate === '') {
+            $_SESSION['oh_error'] = 'Invalid schedule data.';
+            header('Location: opening_hours.php');
+            exit;
+        }
+        $days = [];
+        for ($d = 1; $d <= 7; $d++) {
+            $closed = isset($_POST['sched_closed_' . $d]);
+            $days[$d] = [
+                'is_closed' => $closed,
+                'open_time' => $closed ? null : ($_POST['sched_open_' . $d] ?? null),
+                'close_time' => $closed ? null : ($_POST['sched_close_' . $d] ?? null),
+            ];
+        }
+        oh_update_schedule($id, $name, $startDate, $endDate, $days);
+        $_SESSION['oh_message'] = 'Schedule override updated.';
+        header('Location: opening_hours.php');
+        exit;
+    }
+
+    // --- Delete schedule override ---
+    if ($action === 'delete_schedule') {
+        $id = (int)($_POST['sched_id'] ?? 0);
+        if ($id > 0) {
+            oh_delete_schedule($id);
+            $_SESSION['oh_message'] = 'Schedule override deleted.';
+        }
+        header('Location: opening_hours.php');
+        exit;
+    }
+
+    // --- Create one-off override ---
+    if ($action === 'create_override') {
+        $label = trim($_POST['ovr_label'] ?? '');
+        $startRaw = trim($_POST['ovr_start'] ?? '');
+        $endRaw = trim($_POST['ovr_end'] ?? '');
+        $type = ($_POST['ovr_type'] ?? 'closed') === 'open' ? 'open' : 'closed';
+        if ($startRaw === '' || $endRaw === '') {
+            $_SESSION['oh_error'] = 'Start and end datetime are required.';
+            header('Location: opening_hours.php');
+            exit;
+        }
+        // Form values are in app timezone — convert to UTC for storage
+        $startDt = new DateTime($startRaw, $appTz);
+        $endDt = new DateTime($endRaw, $appTz);
+        $startDt->setTimezone(new DateTimeZone('UTC'));
+        $endDt->setTimezone(new DateTimeZone('UTC'));
+        oh_create_override($label, $startDt->format('Y-m-d H:i:s'), $endDt->format('Y-m-d H:i:s'), $type);
+        $_SESSION['oh_message'] = 'One-off override created.';
+        header('Location: opening_hours.php');
+        exit;
+    }
+
+    // --- Update one-off override ---
+    if ($action === 'update_override') {
+        $id = (int)($_POST['ovr_id'] ?? 0);
+        $label = trim($_POST['ovr_label'] ?? '');
+        $startRaw = trim($_POST['ovr_start'] ?? '');
+        $endRaw = trim($_POST['ovr_end'] ?? '');
+        $type = ($_POST['ovr_type'] ?? 'closed') === 'open' ? 'open' : 'closed';
+        if ($id <= 0 || $startRaw === '' || $endRaw === '') {
+            $_SESSION['oh_error'] = 'Invalid override data.';
+            header('Location: opening_hours.php');
+            exit;
+        }
+        $startDt = new DateTime($startRaw, $appTz);
+        $endDt = new DateTime($endRaw, $appTz);
+        $startDt->setTimezone(new DateTimeZone('UTC'));
+        $endDt->setTimezone(new DateTimeZone('UTC'));
+        oh_update_override($id, $label, $startDt->format('Y-m-d H:i:s'), $endDt->format('Y-m-d H:i:s'), $type);
+        $_SESSION['oh_message'] = 'One-off override updated.';
+        header('Location: opening_hours.php');
+        exit;
+    }
+
+    // --- Delete one-off override ---
+    if ($action === 'delete_override') {
+        $id = (int)($_POST['ovr_id'] ?? 0);
+        if ($id > 0) {
+            oh_delete_override($id);
+            $_SESSION['oh_message'] = 'One-off override deleted.';
+        }
+        header('Location: opening_hours.php');
+        exit;
+    }
+}
+
+// -------------------------------------------------------
+// Load data for display
+// -------------------------------------------------------
+$defaults  = oh_get_default_schedule();
+$schedules = oh_get_schedules();
+$overrides = oh_get_overrides();
+
+$flashMessage = $_SESSION['oh_message'] ?? '';
+$flashError   = $_SESSION['oh_error'] ?? '';
+unset($_SESSION['oh_message'], $_SESSION['oh_error']);
+
+// Editing states
+$editScheduleId = isset($_GET['edit_schedule']) ? (int)$_GET['edit_schedule'] : 0;
+$editSchedule   = $editScheduleId > 0 ? oh_get_schedule($editScheduleId) : null;
+
+$editOverrideId = isset($_GET['edit_override']) ? (int)$_GET['edit_override'] : 0;
+$editOverride   = null;
+if ($editOverrideId > 0) {
+    foreach ($overrides as $ov) {
+        if ((int)$ov['id'] === $editOverrideId) {
+            $editOverride = $ov;
+            break;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Opening Hours – SnipeScheduler</title>
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="assets/style.css">
+    <?= layout_theme_styles($config) ?>
+</head>
+<body class="p-4">
+<div class="container">
+    <div class="page-shell">
+        <?= layout_logo_tag($config) ?>
+        <div class="page-header">
+            <h1>Opening Hours</h1>
+            <div class="page-subtitle">
+                Configure when the facility is open for equipment collection and return.
+            </div>
+        </div>
+
+        <?= layout_render_nav($active, $isStaff, $isAdmin) ?>
+
+        <div class="top-bar mb-3">
+            <div class="top-bar-user">
+                Logged in as:
+                <strong><?= h(trim(($currentUser['first_name'] ?? '') . ' ' . ($currentUser['last_name'] ?? ''))) ?></strong>
+                (<?= h($currentUser['email'] ?? '') ?>)
+            </div>
+            <div class="top-bar-actions">
+                <a href="logout.php" class="btn btn-link btn-sm">Log out</a>
+            </div>
+        </div>
+
+        <ul class="nav nav-tabs reservations-subtabs mb-3">
+            <li class="nav-item">
+                <a class="nav-link" href="activity_log.php">Activity Log</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="settings.php">Settings</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link active" href="opening_hours.php">Opening Hours</a>
+            </li>
+        </ul>
+
+        <?php if ($flashMessage): ?>
+            <div class="alert alert-success"><?= h($flashMessage) ?></div>
+        <?php endif; ?>
+        <?php if ($flashError): ?>
+            <div class="alert alert-danger"><?= h($flashError) ?></div>
+        <?php endif; ?>
+
+        <!-- ============================================================ -->
+        <!-- Card 1: Default Weekly Hours                                 -->
+        <!-- ============================================================ -->
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title mb-1">Default Weekly Hours</h5>
+                <p class="text-muted small mb-3">Set the standard opening hours for each day of the week. These apply unless overridden by a schedule or one-off override below.</p>
+                <form method="post" action="opening_hours.php">
+                    <input type="hidden" name="action" value="save_default">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle">
+                            <thead>
+                                <tr>
+                                    <th>Day</th>
+                                    <th style="width:100px">Closed</th>
+                                    <th>Open</th>
+                                    <th>Close</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php for ($d = 1; $d <= 7; $d++): ?>
+                                    <?php
+                                        $row = $defaults[$d] ?? ['is_closed' => 1, 'open_time' => null, 'close_time' => null];
+                                        $isClosed = (bool)$row['is_closed'];
+                                        $openVal  = $row['open_time'] ? substr($row['open_time'], 0, 5) : '09:00';
+                                        $closeVal = $row['close_time'] ? substr($row['close_time'], 0, 5) : '17:00';
+                                    ?>
+                                    <tr>
+                                        <td class="fw-semibold"><?= h($dayNames[$d]) ?></td>
+                                        <td>
+                                            <input type="checkbox"
+                                                   class="form-check-input oh-closed-toggle"
+                                                   name="default_closed_<?= $d ?>"
+                                                   id="default_closed_<?= $d ?>"
+                                                   data-row="<?= $d ?>"
+                                                   <?= $isClosed ? 'checked' : '' ?>>
+                                        </td>
+                                        <td>
+                                            <input type="time" step="900"
+                                                   class="form-control form-control-sm oh-time-input"
+                                                   name="default_open_<?= $d ?>"
+                                                   id="default_open_<?= $d ?>"
+                                                   value="<?= h($openVal) ?>"
+                                                   <?= $isClosed ? 'disabled' : '' ?>>
+                                        </td>
+                                        <td>
+                                            <input type="time" step="900"
+                                                   class="form-control form-control-sm oh-time-input"
+                                                   name="default_close_<?= $d ?>"
+                                                   id="default_close_<?= $d ?>"
+                                                   value="<?= h($closeVal) ?>"
+                                                   <?= $isClosed ? 'disabled' : '' ?>>
+                                        </td>
+                                    </tr>
+                                <?php endfor; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-sm">Save default hours</button>
+                </form>
+            </div>
+        </div>
+
+        <!-- ============================================================ -->
+        <!-- Card 2: Schedule Overrides                                   -->
+        <!-- ============================================================ -->
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title mb-1">Schedule Overrides</h5>
+                <p class="text-muted small mb-3">Define recurring weekly schedules that override the defaults for a date range (e.g. summer hours, term-time hours).</p>
+
+                <?php if (!empty($schedules)): ?>
+                    <div class="table-responsive mb-3">
+                        <table class="table table-sm table-striped align-middle">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Start Date</th>
+                                    <th>End Date</th>
+                                    <th>Days</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($schedules as $sched): ?>
+                                    <tr>
+                                        <td><?= h($sched['name']) ?></td>
+                                        <td><?= h($sched['start_date']) ?></td>
+                                        <td><?= h($sched['end_date']) ?></td>
+                                        <td>
+                                            <?php
+                                            $daySummary = [];
+                                            foreach ($sched['days'] as $sd) {
+                                                $dn = $dayNames[(int)$sd['day_of_week']] ?? '?';
+                                                if ($sd['is_closed']) {
+                                                    $daySummary[] = substr($dn, 0, 3) . ': Closed';
+                                                } else {
+                                                    $daySummary[] = substr($dn, 0, 3) . ': ' . substr($sd['open_time'], 0, 5) . '-' . substr($sd['close_time'], 0, 5);
+                                                }
+                                            }
+                                            echo h(implode(', ', $daySummary));
+                                            ?>
+                                        </td>
+                                        <td class="text-end text-nowrap">
+                                            <a href="opening_hours.php?edit_schedule=<?= (int)$sched['id'] ?>#schedule-form" class="btn btn-sm btn-outline-primary">Edit</a>
+                                            <form method="post" action="opening_hours.php" class="d-inline" onsubmit="return confirm('Delete this schedule override?');">
+                                                <input type="hidden" name="action" value="delete_schedule">
+                                                <input type="hidden" name="sched_id" value="<?= (int)$sched['id'] ?>">
+                                                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php else: ?>
+                    <p class="text-muted small">No schedule overrides defined.</p>
+                <?php endif; ?>
+
+                <div class="border rounded p-3" id="schedule-form">
+                    <h6 class="fw-semibold mb-2"><?= $editSchedule ? 'Edit' : 'Add' ?> schedule override</h6>
+                    <form method="post" action="opening_hours.php">
+                        <input type="hidden" name="action" value="<?= $editSchedule ? 'update_schedule' : 'create_schedule' ?>">
+                        <?php if ($editSchedule): ?>
+                            <input type="hidden" name="sched_id" value="<?= (int)$editSchedule['id'] ?>">
+                        <?php endif; ?>
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label">Name</label>
+                                <input type="text" name="sched_name" class="form-control form-control-sm" required
+                                       value="<?= h($editSchedule['name'] ?? '') ?>"
+                                       placeholder="e.g. Summer Hours">
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">Start date</label>
+                                <input type="date" name="sched_start" class="form-control form-control-sm" required
+                                       value="<?= h($editSchedule['start_date'] ?? '') ?>">
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">End date</label>
+                                <input type="date" name="sched_end" class="form-control form-control-sm" required
+                                       value="<?= h($editSchedule['end_date'] ?? '') ?>">
+                            </div>
+                        </div>
+                        <?php
+                            $schedDays = [];
+                            if ($editSchedule && !empty($editSchedule['days'])) {
+                                foreach ($editSchedule['days'] as $sd) {
+                                    $schedDays[(int)$sd['day_of_week']] = $sd;
+                                }
+                            }
+                        ?>
+                        <div class="table-responsive mb-3">
+                            <table class="table table-sm align-middle">
+                                <thead>
+                                    <tr>
+                                        <th>Day</th>
+                                        <th style="width:100px">Closed</th>
+                                        <th>Open</th>
+                                        <th>Close</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php for ($d = 1; $d <= 7; $d++): ?>
+                                        <?php
+                                            $sd = $schedDays[$d] ?? null;
+                                            $sClosed = $sd ? (bool)$sd['is_closed'] : ($d >= 6);
+                                            $sOpen  = $sd && $sd['open_time'] ? substr($sd['open_time'], 0, 5) : '09:00';
+                                            $sClose = $sd && $sd['close_time'] ? substr($sd['close_time'], 0, 5) : '17:00';
+                                        ?>
+                                        <tr>
+                                            <td class="fw-semibold"><?= h($dayNames[$d]) ?></td>
+                                            <td>
+                                                <input type="checkbox"
+                                                       class="form-check-input oh-closed-toggle"
+                                                       name="sched_closed_<?= $d ?>"
+                                                       data-row="sched_<?= $d ?>"
+                                                       <?= $sClosed ? 'checked' : '' ?>>
+                                            </td>
+                                            <td>
+                                                <input type="time" step="900"
+                                                       class="form-control form-control-sm oh-time-input"
+                                                       name="sched_open_<?= $d ?>"
+                                                       id="sched_open_<?= $d ?>"
+                                                       value="<?= h($sOpen) ?>"
+                                                       <?= $sClosed ? 'disabled' : '' ?>>
+                                            </td>
+                                            <td>
+                                                <input type="time" step="900"
+                                                       class="form-control form-control-sm oh-time-input"
+                                                       name="sched_close_<?= $d ?>"
+                                                       id="sched_close_<?= $d ?>"
+                                                       value="<?= h($sClose) ?>"
+                                                       <?= $sClosed ? 'disabled' : '' ?>>
+                                            </td>
+                                        </tr>
+                                    <?php endfor; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                        <button type="submit" class="btn btn-primary btn-sm"><?= $editSchedule ? 'Update' : 'Add' ?> schedule override</button>
+                        <?php if ($editSchedule): ?>
+                            <a href="opening_hours.php" class="btn btn-outline-secondary btn-sm ms-2">Cancel</a>
+                        <?php endif; ?>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- ============================================================ -->
+        <!-- Card 3: One-Off Overrides                                    -->
+        <!-- ============================================================ -->
+        <div class="card mb-4">
+            <div class="card-body">
+                <h5 class="card-title mb-1">One-Off Overrides</h5>
+                <p class="text-muted small mb-3">Add specific date/time overrides (e.g. holiday closures, special openings). These take priority over everything else.</p>
+
+                <?php if (!empty($overrides)): ?>
+                    <div class="table-responsive mb-3">
+                        <table class="table table-sm table-striped align-middle">
+                            <thead>
+                                <tr>
+                                    <th>Label</th>
+                                    <th>Start</th>
+                                    <th>End</th>
+                                    <th>Type</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($overrides as $ov): ?>
+                                    <tr>
+                                        <td><?= h($ov['label'] ?: '(no label)') ?></td>
+                                        <td><?= h(app_format_datetime($ov['start_datetime'])) ?></td>
+                                        <td><?= h(app_format_datetime($ov['end_datetime'])) ?></td>
+                                        <td>
+                                            <?php if ($ov['override_type'] === 'closed'): ?>
+                                                <span class="badge bg-danger">Closed</span>
+                                            <?php else: ?>
+                                                <span class="badge bg-success">Open</span>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td class="text-end text-nowrap">
+                                            <a href="opening_hours.php?edit_override=<?= (int)$ov['id'] ?>#override-form" class="btn btn-sm btn-outline-primary">Edit</a>
+                                            <form method="post" action="opening_hours.php" class="d-inline" onsubmit="return confirm('Delete this override?');">
+                                                <input type="hidden" name="action" value="delete_override">
+                                                <input type="hidden" name="ovr_id" value="<?= (int)$ov['id'] ?>">
+                                                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php else: ?>
+                    <p class="text-muted small">No one-off overrides defined.</p>
+                <?php endif; ?>
+
+                <?php
+                    // Convert UTC override datetimes to app-tz for the edit form
+                    $editOvrStart = '';
+                    $editOvrEnd   = '';
+                    if ($editOverride) {
+                        $osDt = new DateTime($editOverride['start_datetime'], new DateTimeZone('UTC'));
+                        $oeDt = new DateTime($editOverride['end_datetime'], new DateTimeZone('UTC'));
+                        $osDt->setTimezone($appTz);
+                        $oeDt->setTimezone($appTz);
+                        $editOvrStart = $osDt->format('Y-m-d\TH:i');
+                        $editOvrEnd   = $oeDt->format('Y-m-d\TH:i');
+                    }
+                ?>
+                <div class="border rounded p-3" id="override-form">
+                    <h6 class="fw-semibold mb-2"><?= $editOverride ? 'Edit' : 'Add' ?> one-off override</h6>
+                    <form method="post" action="opening_hours.php">
+                        <input type="hidden" name="action" value="<?= $editOverride ? 'update_override' : 'create_override' ?>">
+                        <?php if ($editOverride): ?>
+                            <input type="hidden" name="ovr_id" value="<?= (int)$editOverride['id'] ?>">
+                        <?php endif; ?>
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-3">
+                                <label class="form-label">Label</label>
+                                <input type="text" name="ovr_label" class="form-control form-control-sm"
+                                       value="<?= h($editOverride['label'] ?? '') ?>"
+                                       placeholder="e.g. Christmas closure">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">Start</label>
+                                <input type="datetime-local" step="900" name="ovr_start" class="form-control form-control-sm" required
+                                       value="<?= h($editOvrStart) ?>">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">End</label>
+                                <input type="datetime-local" step="900" name="ovr_end" class="form-control form-control-sm" required
+                                       value="<?= h($editOvrEnd) ?>">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">Type</label>
+                                <select name="ovr_type" class="form-select form-select-sm">
+                                    <option value="closed" <?= ($editOverride['override_type'] ?? 'closed') === 'closed' ? 'selected' : '' ?>>Closed</option>
+                                    <option value="open" <?= ($editOverride['override_type'] ?? 'closed') === 'open' ? 'selected' : '' ?>>Open</option>
+                                </select>
+                            </div>
+                        </div>
+                        <button type="submit" class="btn btn-primary btn-sm"><?= $editOverride ? 'Update' : 'Add' ?> one-off override</button>
+                        <?php if ($editOverride): ?>
+                            <a href="opening_hours.php" class="btn btn-outline-secondary btn-sm ms-2">Cancel</a>
+                        <?php endif; ?>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+<?php layout_footer(); ?>
+<script>
+(function () {
+    // Toggle time inputs when "Closed" checkbox changes
+    document.querySelectorAll('.oh-closed-toggle').forEach(function (cb) {
+        cb.addEventListener('change', function () {
+            var row = cb.closest('tr');
+            if (!row) return;
+            var inputs = row.querySelectorAll('.oh-time-input');
+            inputs.forEach(function (inp) {
+                inp.disabled = cb.checked;
+            });
+        });
+    });
+})();
+</script>
+</body>
+</html>

--- a/public/settings.php
+++ b/public/settings.php
@@ -684,6 +684,9 @@ $allowedCategoryIds = array_map('intval', $allowedCategoryIds);
             <li class="nav-item">
                 <a class="nav-link active" href="settings.php">Settings</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link" href="opening_hours.php">Opening Hours</a>
+            </li>
         </ul>
 
         <form method="post" action="<?= h($active) ?>" class="row g-3 settings-form" id="settings-form">

--- a/src/opening_hours.php
+++ b/src/opening_hours.php
@@ -1,0 +1,362 @@
+<?php
+// src/opening_hours.php
+// CRUD and validation helpers for facility opening hours.
+
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/datetime_helpers.php';
+
+$dayNames = [1 => 'Monday', 2 => 'Tuesday', 3 => 'Wednesday', 4 => 'Thursday', 5 => 'Friday', 6 => 'Saturday', 7 => 'Sunday'];
+
+// -------------------------------------------------------
+// Default weekly schedule
+// -------------------------------------------------------
+
+if (!function_exists('oh_get_default_schedule')) {
+    function oh_get_default_schedule(): array
+    {
+        global $pdo;
+        $stmt = $pdo->query('SELECT * FROM opening_hours_default ORDER BY day_of_week ASC');
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $indexed = [];
+        foreach ($rows as $row) {
+            $indexed[(int)$row['day_of_week']] = $row;
+        }
+        return $indexed;
+    }
+}
+
+if (!function_exists('oh_save_default_schedule')) {
+    function oh_save_default_schedule(array $days): void
+    {
+        global $pdo;
+        $stmt = $pdo->prepare('
+            REPLACE INTO opening_hours_default (day_of_week, is_closed, open_time, close_time)
+            VALUES (:dow, :closed, :open, :close)
+        ');
+        foreach ($days as $dow => $info) {
+            $isClosed = !empty($info['is_closed']) ? 1 : 0;
+            $stmt->execute([
+                ':dow'   => (int)$dow,
+                ':closed' => $isClosed,
+                ':open'  => $isClosed ? null : ($info['open_time'] ?? null),
+                ':close' => $isClosed ? null : ($info['close_time'] ?? null),
+            ]);
+        }
+    }
+}
+
+// -------------------------------------------------------
+// Schedule overrides (recurring weekly periods)
+// -------------------------------------------------------
+
+if (!function_exists('oh_get_schedules')) {
+    function oh_get_schedules(): array
+    {
+        global $pdo;
+        $stmt = $pdo->query('SELECT * FROM opening_hours_schedules ORDER BY start_date ASC');
+        $schedules = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $dayStmt = $pdo->prepare('SELECT * FROM opening_hours_schedule_days WHERE schedule_id = :id ORDER BY day_of_week ASC');
+        foreach ($schedules as &$sched) {
+            $dayStmt->execute([':id' => (int)$sched['id']]);
+            $sched['days'] = $dayStmt->fetchAll(PDO::FETCH_ASSOC);
+        }
+        unset($sched);
+        return $schedules;
+    }
+}
+
+if (!function_exists('oh_get_schedule')) {
+    function oh_get_schedule(int $id): ?array
+    {
+        global $pdo;
+        $stmt = $pdo->prepare('SELECT * FROM opening_hours_schedules WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $sched = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$sched) {
+            return null;
+        }
+
+        $dayStmt = $pdo->prepare('SELECT * FROM opening_hours_schedule_days WHERE schedule_id = :id ORDER BY day_of_week ASC');
+        $dayStmt->execute([':id' => $id]);
+        $sched['days'] = $dayStmt->fetchAll(PDO::FETCH_ASSOC);
+        return $sched;
+    }
+}
+
+if (!function_exists('oh_create_schedule')) {
+    function oh_create_schedule(string $name, string $startDate, string $endDate, array $days): int
+    {
+        global $pdo;
+        $pdo->beginTransaction();
+        try {
+            $stmt = $pdo->prepare('
+                INSERT INTO opening_hours_schedules (name, start_date, end_date)
+                VALUES (:name, :start, :end)
+            ');
+            $stmt->execute([':name' => $name, ':start' => $startDate, ':end' => $endDate]);
+            $schedId = (int)$pdo->lastInsertId();
+
+            $dayStmt = $pdo->prepare('
+                INSERT INTO opening_hours_schedule_days (schedule_id, day_of_week, is_closed, open_time, close_time)
+                VALUES (:sid, :dow, :closed, :open, :close)
+            ');
+            foreach ($days as $dow => $info) {
+                $isClosed = !empty($info['is_closed']) ? 1 : 0;
+                $dayStmt->execute([
+                    ':sid'   => $schedId,
+                    ':dow'   => (int)$dow,
+                    ':closed' => $isClosed,
+                    ':open'  => $isClosed ? null : ($info['open_time'] ?? null),
+                    ':close' => $isClosed ? null : ($info['close_time'] ?? null),
+                ]);
+            }
+            $pdo->commit();
+            return $schedId;
+        } catch (Throwable $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+}
+
+if (!function_exists('oh_update_schedule')) {
+    function oh_update_schedule(int $id, string $name, string $startDate, string $endDate, array $days): void
+    {
+        global $pdo;
+        $pdo->beginTransaction();
+        try {
+            $stmt = $pdo->prepare('
+                UPDATE opening_hours_schedules SET name = :name, start_date = :start, end_date = :end WHERE id = :id
+            ');
+            $stmt->execute([':id' => $id, ':name' => $name, ':start' => $startDate, ':end' => $endDate]);
+
+            $pdo->prepare('DELETE FROM opening_hours_schedule_days WHERE schedule_id = :id')->execute([':id' => $id]);
+
+            $dayStmt = $pdo->prepare('
+                INSERT INTO opening_hours_schedule_days (schedule_id, day_of_week, is_closed, open_time, close_time)
+                VALUES (:sid, :dow, :closed, :open, :close)
+            ');
+            foreach ($days as $dow => $info) {
+                $isClosed = !empty($info['is_closed']) ? 1 : 0;
+                $dayStmt->execute([
+                    ':sid'   => $id,
+                    ':dow'   => (int)$dow,
+                    ':closed' => $isClosed,
+                    ':open'  => $isClosed ? null : ($info['open_time'] ?? null),
+                    ':close' => $isClosed ? null : ($info['close_time'] ?? null),
+                ]);
+            }
+            $pdo->commit();
+        } catch (Throwable $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+}
+
+if (!function_exists('oh_delete_schedule')) {
+    function oh_delete_schedule(int $id): void
+    {
+        global $pdo;
+        $pdo->prepare('DELETE FROM opening_hours_schedules WHERE id = :id')->execute([':id' => $id]);
+    }
+}
+
+// -------------------------------------------------------
+// One-off overrides
+// -------------------------------------------------------
+
+if (!function_exists('oh_get_overrides')) {
+    function oh_get_overrides(): array
+    {
+        global $pdo;
+        $stmt = $pdo->query('SELECT * FROM opening_hours_overrides ORDER BY start_datetime ASC');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+
+if (!function_exists('oh_create_override')) {
+    function oh_create_override(string $label, string $startUtc, string $endUtc, string $type): int
+    {
+        global $pdo;
+        $stmt = $pdo->prepare('
+            INSERT INTO opening_hours_overrides (label, start_datetime, end_datetime, override_type)
+            VALUES (:label, :start, :end, :type)
+        ');
+        $stmt->execute([':label' => $label, ':start' => $startUtc, ':end' => $endUtc, ':type' => $type]);
+        return (int)$pdo->lastInsertId();
+    }
+}
+
+if (!function_exists('oh_update_override')) {
+    function oh_update_override(int $id, string $label, string $startUtc, string $endUtc, string $type): void
+    {
+        global $pdo;
+        $stmt = $pdo->prepare('
+            UPDATE opening_hours_overrides
+            SET label = :label, start_datetime = :start, end_datetime = :end, override_type = :type
+            WHERE id = :id
+        ');
+        $stmt->execute([':id' => $id, ':label' => $label, ':start' => $startUtc, ':end' => $endUtc, ':type' => $type]);
+    }
+}
+
+if (!function_exists('oh_delete_override')) {
+    function oh_delete_override(int $id): void
+    {
+        global $pdo;
+        $pdo->prepare('DELETE FROM opening_hours_overrides WHERE id = :id')->execute([':id' => $id]);
+    }
+}
+
+// -------------------------------------------------------
+// Resolution: effective hours for a given date
+// -------------------------------------------------------
+
+if (!function_exists('oh_get_hours_for_date')) {
+    /**
+     * Get effective opening hours for a date string (app-timezone, Y-m-d).
+     * Priority: one-off overrides > schedule overrides > default.
+     *
+     * @return array{is_closed: bool, open_time: ?string, close_time: ?string, source: string}
+     */
+    function oh_get_hours_for_date(string $dateStr): array
+    {
+        global $pdo;
+        $appTz = app_get_timezone();
+
+        // 1. Check one-off overrides whose UTC range covers any part of this app-tz date
+        $dayStart = new DateTime($dateStr . ' 00:00:00', $appTz);
+        $dayEnd   = new DateTime($dateStr . ' 23:59:59', $appTz);
+        $dayStartUtc = (clone $dayStart)->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+        $dayEndUtc   = (clone $dayEnd)->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+
+        $stmt = $pdo->prepare('
+            SELECT * FROM opening_hours_overrides
+            WHERE start_datetime <= :day_end AND end_datetime >= :day_start
+            ORDER BY id DESC LIMIT 1
+        ');
+        $stmt->execute([':day_start' => $dayStartUtc, ':day_end' => $dayEndUtc]);
+        $override = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($override) {
+            $isClosed = ($override['override_type'] === 'closed');
+            return [
+                'is_closed'  => $isClosed,
+                'open_time'  => $isClosed ? null : '00:00:00',
+                'close_time' => $isClosed ? null : '23:59:59',
+                'source'     => 'override: ' . ($override['label'] ?: 'One-off #' . $override['id']),
+            ];
+        }
+
+        // 2. Check schedule overrides active on this date
+        $dow = (int)(new DateTime($dateStr))->format('N'); // 1=Mon..7=Sun
+        $stmt = $pdo->prepare('
+            SELECT sd.* FROM opening_hours_schedule_days sd
+            JOIN opening_hours_schedules s ON s.id = sd.schedule_id
+            WHERE s.start_date <= :date AND s.end_date >= :date
+              AND sd.day_of_week = :dow
+            ORDER BY s.id DESC LIMIT 1
+        ');
+        $stmt->execute([':date' => $dateStr, ':dow' => $dow]);
+        $schedDay = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($schedDay) {
+            return [
+                'is_closed'  => (bool)$schedDay['is_closed'],
+                'open_time'  => $schedDay['open_time'],
+                'close_time' => $schedDay['close_time'],
+                'source'     => 'schedule',
+            ];
+        }
+
+        // 3. Default schedule
+        $stmt = $pdo->prepare('SELECT * FROM opening_hours_default WHERE day_of_week = :dow');
+        $stmt->execute([':dow' => $dow]);
+        $default = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($default) {
+            return [
+                'is_closed'  => (bool)$default['is_closed'],
+                'open_time'  => $default['open_time'],
+                'close_time' => $default['close_time'],
+                'source'     => 'default',
+            ];
+        }
+
+        // No data at all — treat as closed
+        return ['is_closed' => true, 'open_time' => null, 'close_time' => null, 'source' => 'none'];
+    }
+}
+
+if (!function_exists('oh_is_open_at')) {
+    /**
+     * Check if the facility is open at a specific UTC datetime.
+     */
+    function oh_is_open_at(DateTime $utcDt): bool
+    {
+        $appTz = app_get_timezone();
+        $local = (clone $utcDt)->setTimezone($appTz);
+        $dateStr = $local->format('Y-m-d');
+        $timeStr = $local->format('H:i:s');
+
+        $hours = oh_get_hours_for_date($dateStr);
+        if ($hours['is_closed']) {
+            return false;
+        }
+        if ($hours['open_time'] === null || $hours['close_time'] === null) {
+            return false;
+        }
+        return ($timeStr >= $hours['open_time'] && $timeStr <= $hours['close_time']);
+    }
+}
+
+if (!function_exists('oh_validate_reservation_window')) {
+    /**
+     * Validate a reservation start/end (UTC) against opening hours.
+     * Returns an array of error strings (empty = valid).
+     */
+    function oh_validate_reservation_window(DateTime $startUtc, DateTime $endUtc): array
+    {
+        global $dayNames;
+        $errors = [];
+        $appTz = app_get_timezone();
+
+        $localStart = (clone $startUtc)->setTimezone($appTz);
+        $localEnd   = (clone $endUtc)->setTimezone($appTz);
+
+        // Check start time
+        $startDate = $localStart->format('Y-m-d');
+        $startTime = $localStart->format('H:i:s');
+        $startHours = oh_get_hours_for_date($startDate);
+        $startDow = (int)$localStart->format('N');
+        $startDayName = $dayNames[$startDow] ?? $startDate;
+
+        if ($startHours['is_closed']) {
+            $errors[] = 'Collection date (' . $startDayName . ', ' . app_format_date($startDate) . ') is outside opening hours — the facility is closed.';
+        } elseif ($startHours['open_time'] !== null && $startHours['close_time'] !== null) {
+            if ($startTime < $startHours['open_time'] || $startTime > $startHours['close_time']) {
+                $openFmt = substr($startHours['open_time'], 0, 5);
+                $closeFmt = substr($startHours['close_time'], 0, 5);
+                $errors[] = 'Collection time (' . $localStart->format('H:i') . ') is outside opening hours on ' . $startDayName . ' (' . $openFmt . ' – ' . $closeFmt . ').';
+            }
+        }
+
+        // Check end time
+        $endDate = $localEnd->format('Y-m-d');
+        $endTime = $localEnd->format('H:i:s');
+        $endHours = oh_get_hours_for_date($endDate);
+        $endDow = (int)$localEnd->format('N');
+        $endDayName = $dayNames[$endDow] ?? $endDate;
+
+        if ($endHours['is_closed']) {
+            $errors[] = 'Return date (' . $endDayName . ', ' . app_format_date($endDate) . ') is outside opening hours — the facility is closed.';
+        } elseif ($endHours['open_time'] !== null && $endHours['close_time'] !== null) {
+            if ($endTime < $endHours['open_time'] || $endTime > $endHours['close_time']) {
+                $openFmt = substr($endHours['open_time'], 0, 5);
+                $closeFmt = substr($endHours['close_time'], 0, 5);
+                $errors[] = 'Return time (' . $localEnd->format('H:i') . ') is outside opening hours on ' . $endDayName . ' (' . $openFmt . ' – ' . $closeFmt . ').';
+            }
+        }
+
+        return $errors;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds facility opening hours with a 3-tier priority system: one-off overrides > schedule overrides > default weekly schedule
- New admin page (Admin > Opening Hours) for managing default hours, recurring schedule overrides, and one-off date/time overrides
- Basket and basket checkout enforce opening hours as blocking errors for end users; staff/admin reservation editing is not restricted
- Includes v1.2.0 migration (4 new tables) and schema baseline update for fresh installs

## New files
- `public/install/upgrade/v1.2.0.sql` — Migration: 4 tables + Mon-Fri 09:00-17:00 seed
- `src/opening_hours.php` — CRUD helpers, priority resolution, reservation window validation
- `public/opening_hours.php` — Admin CRUD page (3 cards: defaults, schedules, one-offs)

## Modified files
- `public/install/schema.sql` — Baseline schema for fresh installs
- `public/settings.php` / `public/activity_log.php` — Opening Hours tab in admin sub-nav
- `public/basket.php` — Blocking errors in `$checkoutErrors` for invalid times
- `public/basket_checkout.php` — Server-side enforcement via `basket_error()`

## Test plan
- [x] Run v1.2.0 upgrade — tables created, default hours seeded
- [x] Admin > Opening Hours tab visible — default Mon-Fri 09:00-17:00 shown
- [x] Edit default hours (e.g. close Wednesdays) — save — persisted
- [x] Add a schedule override (e.g. "Summer Hours" Jun 1-Aug 31) — shows in list
- [x] Add a one-off override (e.g. "Christmas Closure" Dec 24-26, closed) — shows in list
- [x] Basket: set reservation start to Saturday — red error, submit disabled
- [x] Basket: set reservation to weekday during opening hours — no error
- [x] Confirm booking for valid times — reservation created
- [x] Confirm booking for invalid times (bypass attempt) — basket_checkout blocks with error
- [x] Staff > reservation_edit.php — can save any times without restriction

🤖 Generated with [Claude Code](https://claude.com/claude-code)