### PR TITLE
Fix #40: Sort open reservations above closed on My Bookings

### DIFF
--- a/public/my_bookings.php
+++ b/public/my_bookings.php
@@ -30,7 +30,9 @@ try {
         SELECT *
         FROM reservations
         WHERE user_id = :user_id
-        ORDER BY start_datetime DESC
+        ORDER BY
+            CASE WHEN status IN ('pending','confirmed') THEN 0 ELSE 1 END,
+            start_datetime DESC
     ";
     $stmt = $pdo->prepare($sql);
     $stmt->execute([':user_id' => $currentUserId]);


### PR DESCRIPTION
## Summary
- Pending/confirmed reservations now sort to the top of the My Bookings page
- Fulfilled/cancelled/missed reservations appear below
- Each group remains sorted by newest start date first

Closes #40

## Test plan
- [ ] Visit My Reservations page with mixed-status bookings
- [ ] Verify pending/confirmed reservations appear at the top, newest first
- [ ] Verify fulfilled/cancelled/missed reservations appear below, newest first

🤖 Generated with [Claude Code](https://claude.com/claude-code)