### PR TITLE
Fix #30: Rename Active Checkouts tab to Checked Out Items

### DIFF
--- a/public/reservations.php
+++ b/public/reservations.php
@@ -113,7 +113,7 @@ if (!$tabFile || !is_file($tabFile)) {
             </li>
             <li class="nav-item">
                 <a class="nav-link <?= $tab === 'checked_out' ? 'active' : '' ?>"
-                   href="reservations.php?tab=checked_out">Active Checkouts</a>
+                   href="reservations.php?tab=checked_out">Checked Out Items</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link <?= $tab === 'history' ? 'active' : '' ?>"


### PR DESCRIPTION
## Summary
- Renames the "Active Checkouts" tab to "Checked Out Items" on the reservations page
- The old name was misleading since the tab shows checked-out items, not checkout sessions

Closes #30

## Test plan
- [ ] Visit the reservations page and verify the tab now reads "Checked Out Items"
- [ ] Verify the tab still links to the correct `?tab=checked_out` view

🤖 Generated with [Claude Code](https://claude.com/claude-code)