### PR TITLE
Fix #27: Handle implicit commit from DDL during upgrades

### DIFF
--- a/public/install/upgrade/index.php
+++ b/public/install/upgrade/index.php
@@ -88,7 +88,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'run')
                 $pdo->exec($sql);
                 $stmt = $pdo->prepare('INSERT IGNORE INTO schema_version (version) VALUES (:version)');
                 $stmt->execute([':version' => $version]);
-                $pdo->commit();
+                if ($pdo->inTransaction()) {
+                    $pdo->commit();
+                }
                 $messages[] = "Applied upgrade {$version}.";
             } catch (Throwable $e) {
                 if ($pdo->inTransaction()) {


### PR DESCRIPTION
## Summary
- MySQL DDL statements (`CREATE TABLE`, `ALTER TABLE`) trigger implicit commits that silently end the PDO transaction
- Added `inTransaction()` check before calling `commit()` so the upgrade succeeds cleanly instead of showing a false "no active transaction" error
- Schema changes were always being applied — this just eliminates the spurious error alert

## Test plan
- [ ] Run a database upgrade containing DDL statements
- [ ] Verify only the success message appears (no "no active transaction" error)
- [ ] Reload the upgrade page and confirm no pending upgrades remain

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)