### PR TITLE
Show user access levels and certs in booking-for alert

### DIFF
--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -492,6 +492,8 @@ if ($isStaff && $_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['mode'] ?? '') 
             'snipeit_user_id' => resolve_snipeit_user_id($selEmail),
         ];
     }
+    // Bust cached user groups so auth badges and permissions refresh immediately
+    unset($_SESSION['snipeit_user_groups']);
     header('Location: catalogue.php');
     exit;
 }


### PR DESCRIPTION
## Summary

- Displays the active user's `Access - *` (blue) and `Cert - *` (yellow) group badges in the staff "Booking for" banner
- Uses the already-cached `get_user_groups()` call so no extra API requests
- Helps staff see at a glance what a user is authorized to reserve

## Test plan

- [ ] As staff, verify badges appear next to user name in the booking-for alert
- [ ] Switch booking user — badges update to reflect new user's groups
- [ ] User with no Access/Cert groups shows no badges
- [ ] User with multiple groups shows all relevant badges

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)