### PR TITLE
Reword active checkout alert in basket

### DIFF
--- a/public/basket.php
+++ b/public/basket.php
@@ -260,12 +260,7 @@ if (!empty($basket) && $bookingEmail !== '') {
     ");
     $acStmt->execute([':email' => $bookingEmail]);
     $activeCheckout = $acStmt->fetch(PDO::FETCH_ASSOC);
-    if ($activeCheckout) {
-        $returnDate = app_format_datetime($activeCheckout['end_datetime']);
-        $checkoutWarnings[] = 'You have an active checkout (return expected ' . $returnDate . '). '
-            . 'New items will be appended to your existing checkout. '
-            . 'If the dates differ, consider adjusting the return date.';
-    }
+    $activeCheckoutReturnDate = $activeCheckout ? app_format_datetime($activeCheckout['end_datetime']) : '';
 }
 
 if (!empty($basket)) {
@@ -546,6 +541,17 @@ if (!empty($basket)) {
                         <?php foreach ($checkoutErrors as $err): ?>
                             <li><?= h($err) ?></li>
                         <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
+
+            <?php if (!empty($activeCheckout)): ?>
+                <div class="alert alert-warning">
+                    <strong>You have an active checkout</strong> (return expected <?= h($activeCheckoutReturnDate) ?>).
+                    <p class="mb-2 mt-2">New items will be added to your existing checkout and will use the existing return date. Your selected dates will be ignored.</p>
+                    <ul class="mb-0">
+                        <li><strong>To continue:</strong> click <em>Confirm booking</em> below. Items will be appended to your current checkout.</li>
+                        <li><strong>To create a separate reservation:</strong> go back to the <a href="catalogue.php">catalogue</a> and choose dates that don't overlap with your current checkout.</li>
                     </ul>
                 </div>
             <?php endif; ?>


### PR DESCRIPTION
## Summary

- Replaces the vague "consider adjusting the return date" message with a clear explanation that selected dates will be ignored and items appended to the existing checkout
- Gives two actionable options: continue with the booking (append), or go back to catalogue and pick non-overlapping dates
- Separates the active checkout alert from other warnings for better visibility

## Test plan

- [ ] With an active checkout, verify the new alert appears with the expected return date
- [ ] Confirm the catalogue link works to navigate back
- [ ] With no active checkout, verify no alert appears
- [ ] Other warnings (undeployable units) still display separately

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)