### PR TITLE
Fix checkout history search to match user email

### DIFF
--- a/public/checkout_history.php
+++ b/public/checkout_history.php
@@ -60,10 +60,11 @@ try {
 
     if ($q !== null) {
         $joinItems = true;
-        $where[] = '(c.user_name LIKE :q OR ci.asset_tag LIKE :q2 OR ci.asset_name LIKE :q3)';
+        $where[] = '(c.user_name LIKE :q OR c.user_email LIKE :q4 OR ci.asset_tag LIKE :q2 OR ci.asset_name LIKE :q3)';
         $params[':q']  = '%' . $q . '%';
         $params[':q2'] = '%' . $q . '%';
         $params[':q3'] = '%' . $q . '%';
+        $params[':q4'] = '%' . $q . '%';
     }
 
     if ($dateFrom !== null) {

--- a/public/my_bookings.php
+++ b/public/my_bookings.php
@@ -251,7 +251,7 @@ if (!empty($_GET['deleted'])) {
                                     <?php if ($linkedCheckout): ?>
                                         <br><strong>Checkout:</strong>
                                         <?php if ($isStaff): ?>
-                                            <a href="checkout_history.php?q=<?= urlencode($res['user_name'] ?? '') ?>">
+                                            <a href="checkout_history.php?q=<?= urlencode($res['user_email'] ?? '') ?>">
                                                 #<?= (int)$linkedCheckout['id'] ?> (<?= h($linkedCheckout['status']) ?>)
                                             </a>
                                         <?php else: ?>
@@ -355,7 +355,7 @@ if (!empty($_GET['deleted'])) {
                                         <?php if ($linkedCheckout): ?>
                                             <br><strong>Checkout:</strong>
                                             <?php if ($isStaff): ?>
-                                                <a href="checkout_history.php?q=<?= urlencode($res['user_name'] ?? '') ?>">
+                                                <a href="checkout_history.php?q=<?= urlencode($res['user_email'] ?? '') ?>">
                                                     #<?= (int)$linkedCheckout['id'] ?> (<?= h($linkedCheckout['status']) ?>)
                                                 </a>
                                             <?php else: ?>


### PR DESCRIPTION
## Summary

- Adds `user_email` to the checkout_history.php search filter so searching by email works
- Changes the checkout link in my_bookings.php to search by email instead of user name for reliable matching

## Test plan

- [ ] Staff checkout link from my_bookings goes to checkout_history with correct results
- [ ] Searching checkout history by email returns matching checkouts
- [ ] Searching by name or asset tag still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)