### PR TITLE
Play audible beep on successful barcode scan

### DIFF
--- a/public/quick_checkin.php
+++ b/public/quick_checkin.php
@@ -709,6 +709,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </div>
 <script>
 (function () {
+    // Play a short beep on successful scan via Web Audio API
+    function playBeep() {
+        try {
+            const ctx = new (window.AudioContext || window.webkitAudioContext)();
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'sine';
+            osc.frequency.value = 880;
+            gain.gain.value = 0.8;
+            osc.connect(gain);
+            gain.connect(ctx.destination);
+            osc.start();
+            osc.stop(ctx.currentTime + 0.15);
+        } catch (e) {}
+    }
+
+    // Beep once when scan input receives focus after a successful scan
+    if (document.querySelector('.alert-success')) {
+        const scanInput = document.querySelector('.asset-autocomplete');
+        if (scanInput) {
+            scanInput.addEventListener('focus', () => playBeep(), { once: true });
+        }
+    }
+
     const assetWrappers = document.querySelectorAll('.asset-autocomplete-wrapper');
     assetWrappers.forEach((wrapper) => {
         const input = wrapper.querySelector('.asset-autocomplete');

--- a/public/quick_checkout.php
+++ b/public/quick_checkout.php
@@ -741,6 +741,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 <script>
 (function () {
+    // Play a short beep on successful scan via Web Audio API
+    function playBeep() {
+        try {
+            const ctx = new (window.AudioContext || window.webkitAudioContext)();
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'sine';
+            osc.frequency.value = 880;
+            gain.gain.value = 0.8;
+            osc.connect(gain);
+            gain.connect(ctx.destination);
+            osc.start();
+            osc.stop(ctx.currentTime + 0.15);
+        } catch (e) {}
+    }
+
+    // Beep once when scan input receives focus after a successful scan
+    if (document.querySelector('.alert-success')) {
+        const scanInput = document.querySelector('.asset-autocomplete');
+        if (scanInput) {
+            scanInput.addEventListener('focus', () => playBeep(), { once: true });
+        }
+    }
+
     const assetWrappers = document.querySelectorAll('.asset-autocomplete-wrapper');
     assetWrappers.forEach((wrapper) => {
         const input = wrapper.querySelector('.asset-autocomplete');

--- a/public/staff_checkout.php
+++ b/public/staff_checkout.php
@@ -1738,10 +1738,31 @@ $active  = basename($_SERVER['PHP_SELF']);
         sessionStorage.removeItem(scrollKey);
     }
 
+    // Play a short beep on successful scan via Web Audio API
+    function playBeep() {
+        try {
+            const ctx = new (window.AudioContext || window.webkitAudioContext)();
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'sine';
+            osc.frequency.value = 880;
+            gain.gain.value = 0.8;
+            osc.connect(gain);
+            gain.connect(ctx.destination);
+            osc.start();
+            osc.stop(ctx.currentTime + 0.15);
+        } catch (e) {}
+    }
+
     // Auto-focus scan input after scroll restoration
     const scanInput = document.getElementById('scan-tag-input');
     if (scanInput) {
-        setTimeout(() => scanInput.focus(), 50);
+        setTimeout(() => {
+            scanInput.focus();
+            if (document.querySelector('.alert-success')) {
+                playBeep();
+            }
+        }, 50);
     }
 
     document.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- Adds a Web Audio API beep (880 Hz, 150ms) on `staff_checkout.php`, `quick_checkout.php`, and `quick_checkin.php` after a successful barcode scan
- Beep is gated on `.alert-success` being present, so it only fires when the app accepted the scan — not on errors or initial page load
- No audio files or dependencies; works in all modern browsers

## Test plan
- [ ] On `staff_checkout.php` (Today tab), scan a barcode — page reloads, success alert appears, beep plays, input is focused
- [ ] On `quick_checkout.php`, scan a barcode — beep plays on success
- [ ] On `quick_checkin.php`, scan a barcode — beep plays on success
- [ ] Scan an invalid tag — `.alert-danger` only, no beep
- [ ] Load any of the three pages fresh (no scan) — no beep

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)