### PR TITLE
Fix scan beep blocked by browser autoplay policy

### DIFF
--- a/public/quick_checkin.php
+++ b/public/quick_checkin.php
@@ -709,28 +709,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </div>
 <script>
 (function () {
-    // Play a short beep on successful scan via Web Audio API
-    function playBeep() {
-        try {
-            const ctx = new (window.AudioContext || window.webkitAudioContext)();
-            const osc = ctx.createOscillator();
-            const gain = ctx.createGain();
-            osc.type = 'sine';
-            osc.frequency.value = 880;
-            gain.gain.value = 0.8;
-            osc.connect(gain);
-            gain.connect(ctx.destination);
-            osc.start();
-            osc.stop(ctx.currentTime + 0.15);
-        } catch (e) {}
-    }
-
-    // Beep once when scan input receives focus after a successful scan
+    // Beep on first user interaction after a successful scan (deferred for autoplay policy)
     if (document.querySelector('.alert-success')) {
-        const scanInput = document.querySelector('.asset-autocomplete');
-        if (scanInput) {
-            scanInput.addEventListener('focus', () => playBeep(), { once: true });
+        const ac = new AbortController();
+        function beepOnce() {
+            ac.abort();
+            try {
+                const ctx = new (window.AudioContext || window.webkitAudioContext)();
+                const osc = ctx.createOscillator();
+                const gain = ctx.createGain();
+                osc.type = 'sine';
+                osc.frequency.value = 880;
+                gain.gain.value = 0.8;
+                osc.connect(gain);
+                gain.connect(ctx.destination);
+                osc.start();
+                osc.stop(ctx.currentTime + 0.15);
+            } catch (e) {}
         }
+        document.addEventListener('keydown', beepOnce, { signal: ac.signal });
+        document.addEventListener('click', beepOnce, { signal: ac.signal });
+        document.addEventListener('touchstart', beepOnce, { signal: ac.signal });
     }
 
     const assetWrappers = document.querySelectorAll('.asset-autocomplete-wrapper');

--- a/public/quick_checkout.php
+++ b/public/quick_checkout.php
@@ -741,28 +741,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 <script>
 (function () {
-    // Play a short beep on successful scan via Web Audio API
-    function playBeep() {
-        try {
-            const ctx = new (window.AudioContext || window.webkitAudioContext)();
-            const osc = ctx.createOscillator();
-            const gain = ctx.createGain();
-            osc.type = 'sine';
-            osc.frequency.value = 880;
-            gain.gain.value = 0.8;
-            osc.connect(gain);
-            gain.connect(ctx.destination);
-            osc.start();
-            osc.stop(ctx.currentTime + 0.15);
-        } catch (e) {}
-    }
-
-    // Beep once when scan input receives focus after a successful scan
+    // Beep on first user interaction after a successful scan (deferred for autoplay policy)
     if (document.querySelector('.alert-success')) {
-        const scanInput = document.querySelector('.asset-autocomplete');
-        if (scanInput) {
-            scanInput.addEventListener('focus', () => playBeep(), { once: true });
+        const ac = new AbortController();
+        function beepOnce() {
+            ac.abort();
+            try {
+                const ctx = new (window.AudioContext || window.webkitAudioContext)();
+                const osc = ctx.createOscillator();
+                const gain = ctx.createGain();
+                osc.type = 'sine';
+                osc.frequency.value = 880;
+                gain.gain.value = 0.8;
+                osc.connect(gain);
+                gain.connect(ctx.destination);
+                osc.start();
+                osc.stop(ctx.currentTime + 0.15);
+            } catch (e) {}
         }
+        document.addEventListener('keydown', beepOnce, { signal: ac.signal });
+        document.addEventListener('click', beepOnce, { signal: ac.signal });
+        document.addEventListener('touchstart', beepOnce, { signal: ac.signal });
     }
 
     const assetWrappers = document.querySelectorAll('.asset-autocomplete-wrapper');

--- a/public/staff_checkout.php
+++ b/public/staff_checkout.php
@@ -1738,31 +1738,33 @@ $active  = basename($_SERVER['PHP_SELF']);
         sessionStorage.removeItem(scrollKey);
     }
 
-    // Play a short beep on successful scan via Web Audio API
-    function playBeep() {
-        try {
-            const ctx = new (window.AudioContext || window.webkitAudioContext)();
-            const osc = ctx.createOscillator();
-            const gain = ctx.createGain();
-            osc.type = 'sine';
-            osc.frequency.value = 880;
-            gain.gain.value = 0.8;
-            osc.connect(gain);
-            gain.connect(ctx.destination);
-            osc.start();
-            osc.stop(ctx.currentTime + 0.15);
-        } catch (e) {}
+    // Beep on first user interaction after a successful scan (deferred for autoplay policy)
+    if (document.querySelector('.alert-success')) {
+        const ac = new AbortController();
+        function beepOnce() {
+            ac.abort();
+            try {
+                const ctx = new (window.AudioContext || window.webkitAudioContext)();
+                const osc = ctx.createOscillator();
+                const gain = ctx.createGain();
+                osc.type = 'sine';
+                osc.frequency.value = 880;
+                gain.gain.value = 0.8;
+                osc.connect(gain);
+                gain.connect(ctx.destination);
+                osc.start();
+                osc.stop(ctx.currentTime + 0.15);
+            } catch (e) {}
+        }
+        document.addEventListener('keydown', beepOnce, { signal: ac.signal });
+        document.addEventListener('click', beepOnce, { signal: ac.signal });
+        document.addEventListener('touchstart', beepOnce, { signal: ac.signal });
     }
 
     // Auto-focus scan input after scroll restoration
     const scanInput = document.getElementById('scan-tag-input');
     if (scanInput) {
-        setTimeout(() => {
-            scanInput.focus();
-            if (document.querySelector('.alert-success')) {
-                playBeep();
-            }
-        }, 50);
+        setTimeout(() => scanInput.focus(), 50);
     }
 
     document.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- Browsers block `AudioContext` from starting automatically on page load — it requires a user gesture
- Defers beep creation to the first `keydown`, `click`, or `touchstart` event after page load
- The barcode scanner sends keystrokes, so the beep fires on the first character of the next scan
- Uses `AbortController` to cleanly remove all three listeners after the first fires

## Test plan
- [ ] Scan a barcode on `staff_checkout.php` — beep plays when next scan starts (no console warning)
- [ ] Scan a barcode on `quick_checkout.php` — same behavior
- [ ] Scan a barcode on `quick_checkin.php` — same behavior
- [ ] No beep on initial page load or failed scans

Generated with [Claude Code](https://claude.com/claude-code)