### PR TITLE
Fix autocomplete broken in embedded staff checkout

### DIFF
--- a/public/staff_checkout.php
+++ b/public/staff_checkout.php
@@ -1812,7 +1812,7 @@ $active  = basename($_SERVER['PHP_SELF']);
 
         function fetchSuggestions(q) {
             lastQuery = q;
-            fetch('<?= h($ajaxBase) ?>ajax=user_search&q=' + encodeURIComponent(q), {
+            fetch(<?= json_encode($ajaxBase) ?> + 'ajax=user_search&q=' + encodeURIComponent(q), {
                 headers: { 'X-Requested-With': 'XMLHttpRequest' }
             })
                 .then((res) => res.ok ? res.json() : Promise.reject())
@@ -1939,7 +1939,7 @@ $active  = basename($_SERVER['PHP_SELF']);
 
         function fetchSuggestions(q) {
             lastQuery = q;
-            fetch('<?= h($ajaxBase) ?>ajax=asset_search&q=' + encodeURIComponent(q), {
+            fetch(<?= json_encode($ajaxBase) ?> + 'ajax=asset_search&q=' + encodeURIComponent(q), {
                 headers: { 'X-Requested-With': 'XMLHttpRequest' }
             })
                 .then((res) => res.ok ? res.json() : Promise.reject())


### PR DESCRIPTION
## Summary
- Asset and user autocomplete on `staff_checkout.php` did not work when accessed via `reservations.php?tab=today`
- Root cause: `h()` (HTML escaper) was used to embed the AJAX base URL in a `<script>` tag, encoding `&` as `&amp;`. Since HTML entities are NOT decoded inside `<script>` elements, the fetch URL was corrupted (e.g. `&amp;ajax=asset_search` instead of `&ajax=asset_search`)
- Fix: use `json_encode()` instead, which is the correct escaper for JavaScript string context

## Test plan
- [ ] Go to `reservations.php?tab=today`, select a reservation, type in the scan input — autocomplete suggestions appear
- [ ] User search autocomplete also works in the embedded view
- [ ] Direct access to `staff_checkout.php` still works (no `&` in that URL, so unaffected)

Closes #66

Generated with [Claude Code](https://claude.com/claude-code)