### PR TITLE
Revert scan beep — blocked by browser autoplay policy

### DIFF
--- a/public/quick_checkin.php
+++ b/public/quick_checkin.php
@@ -709,29 +709,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </div>
 <script>
 (function () {
-    // Beep on first user interaction after a successful scan (deferred for autoplay policy)
-    if (document.querySelector('.alert-success')) {
-        const ac = new AbortController();
-        function beepOnce() {
-            ac.abort();
-            try {
-                const ctx = new (window.AudioContext || window.webkitAudioContext)();
-                const osc = ctx.createOscillator();
-                const gain = ctx.createGain();
-                osc.type = 'sine';
-                osc.frequency.value = 880;
-                gain.gain.value = 0.8;
-                osc.connect(gain);
-                gain.connect(ctx.destination);
-                osc.start();
-                osc.stop(ctx.currentTime + 0.15);
-            } catch (e) {}
-        }
-        document.addEventListener('keydown', beepOnce, { signal: ac.signal });
-        document.addEventListener('click', beepOnce, { signal: ac.signal });
-        document.addEventListener('touchstart', beepOnce, { signal: ac.signal });
-    }
-
     const assetWrappers = document.querySelectorAll('.asset-autocomplete-wrapper');
     assetWrappers.forEach((wrapper) => {
         const input = wrapper.querySelector('.asset-autocomplete');

--- a/public/quick_checkout.php
+++ b/public/quick_checkout.php
@@ -741,29 +741,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 <script>
 (function () {
-    // Beep on first user interaction after a successful scan (deferred for autoplay policy)
-    if (document.querySelector('.alert-success')) {
-        const ac = new AbortController();
-        function beepOnce() {
-            ac.abort();
-            try {
-                const ctx = new (window.AudioContext || window.webkitAudioContext)();
-                const osc = ctx.createOscillator();
-                const gain = ctx.createGain();
-                osc.type = 'sine';
-                osc.frequency.value = 880;
-                gain.gain.value = 0.8;
-                osc.connect(gain);
-                gain.connect(ctx.destination);
-                osc.start();
-                osc.stop(ctx.currentTime + 0.15);
-            } catch (e) {}
-        }
-        document.addEventListener('keydown', beepOnce, { signal: ac.signal });
-        document.addEventListener('click', beepOnce, { signal: ac.signal });
-        document.addEventListener('touchstart', beepOnce, { signal: ac.signal });
-    }
-
     const assetWrappers = document.querySelectorAll('.asset-autocomplete-wrapper');
     assetWrappers.forEach((wrapper) => {
         const input = wrapper.querySelector('.asset-autocomplete');

--- a/public/staff_checkout.php
+++ b/public/staff_checkout.php
@@ -1738,29 +1738,6 @@ $active  = basename($_SERVER['PHP_SELF']);
         sessionStorage.removeItem(scrollKey);
     }
 
-    // Beep on first user interaction after a successful scan (deferred for autoplay policy)
-    if (document.querySelector('.alert-success')) {
-        const ac = new AbortController();
-        function beepOnce() {
-            ac.abort();
-            try {
-                const ctx = new (window.AudioContext || window.webkitAudioContext)();
-                const osc = ctx.createOscillator();
-                const gain = ctx.createGain();
-                osc.type = 'sine';
-                osc.frequency.value = 880;
-                gain.gain.value = 0.8;
-                osc.connect(gain);
-                gain.connect(ctx.destination);
-                osc.start();
-                osc.stop(ctx.currentTime + 0.15);
-            } catch (e) {}
-        }
-        document.addEventListener('keydown', beepOnce, { signal: ac.signal });
-        document.addEventListener('click', beepOnce, { signal: ac.signal });
-        document.addEventListener('touchstart', beepOnce, { signal: ac.signal });
-    }
-
     // Auto-focus scan input after scroll restoration
     const scanInput = document.getElementById('scan-tag-input');
     if (scanInput) {


### PR DESCRIPTION
## Summary
- Removes the scan beep code added in #70 and revised in #71
- Browser autoplay policy blocks `AudioContext` creation without a user gesture, and a full-page POST/redirect reload does not carry gesture context
- The beep feature needs the scan forms converted to AJAX submissions first so the `AudioContext` can be created during the form submit gesture
- Keeps the `json_encode` autocomplete URL fix from #72 (separate issue)

## Test plan
- [ ] No console warnings about AudioContext on any scan page
- [ ] Autocomplete still works on all three scan pages

Generated with [Claude Code](https://claude.com/claude-code)