### PR TITLE
Fix sync cron using stale cache causing false asset returns

### DIFF
--- a/scripts/sync_checked_out_assets.php
+++ b/scripts/sync_checked_out_assets.php
@@ -19,6 +19,10 @@ require_once SRC_PATH . '/snipeit_client.php';
 require_once SRC_PATH . '/db.php';
 require_once SRC_PATH . '/activity_log.php';
 
+// Bypass API cache — sync must always use fresh data from Snipe-IT
+// to avoid false returns caused by stale cached hardware listings.
+$cacheTtl = 0;
+
 function sync_log(string $msg): void
 {
     echo '[' . date('Y-m-d H:i:s') . '] ' . $msg . "\n";


### PR DESCRIPTION
## Summary
- The sync cron (`sync_checked_out_assets.php`) was using `snipeit_request()` with the default 60s file cache for `GET /hardware` calls
- If a checkout happened within the cache TTL window, the next sync run would get stale data missing the newly checked-out asset
- The reconciliation logic would then incorrectly mark that asset as returned and close the parent checkout
- **Fix**: Set `$cacheTtl = 0` at the top of the sync script so it always fetches fresh data from Snipe-IT

## Root cause
1. Sync cron runs at T+0, caches hardware list (asset X not checked out)
2. Staff checks out asset X at T+30s via Snipe-IT POST (bypasses GET cache)
3. Sync cron runs at T+60s, gets **stale cached response** — asset X missing
4. Reconciliation: "asset X not in cache = returned" → sets `checked_in_at` → closes checkout

## Test plan
- [ ] Run sync cron immediately after creating a checkout — checkout stays open
- [ ] Verify sync still correctly detects actual returns made in Snipe-IT
- [ ] Check that sync script logs show fresh asset count (not cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)