### PR TITLE
Add focus highlight to scan input fields

### DIFF
--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -1280,3 +1280,10 @@ form .form-select {
 .schedule-user {
     font-size: 0.78rem;
 }
+
+/* Scan input focus highlight — makes it obvious where scanned input goes */
+.asset-autocomplete:focus {
+    border-color: var(--primary-strong);
+    box-shadow: 0 0 0 0.25rem rgba(var(--primary-rgb), 0.35);
+    outline: none;
+}


### PR DESCRIPTION
## Summary
- Scan inputs on quick checkout, quick checkin, and staff checkout now show a themed border and glow on focus
- Uses the app primary color for consistency with the theme
- Makes it immediately obvious where scanned barcode input will go if focus is accidentally lost

## Test plan
- [ ] Quick checkout — scan input has colored border/glow when focused
- [ ] Quick checkin — same highlight
- [ ] Staff checkout (reservation scan) — same highlight
- [ ] Click elsewhere to blur — highlight disappears
- [ ] Change theme color in config — highlight follows the new color

Generated with [Claude Code](https://claude.com/claude-code)