### PR TITLE
Reduce kit cache TTL from 24 hours to 5 minutes

### DIFF
--- a/src/snipeit_client.php
+++ b/src/snipeit_client.php
@@ -373,7 +373,7 @@ function get_model_hardware_count(int $modelId): int
 /**
  * Fetch all predefined kits from Snipe-IT.
  *
- * Uses 24h outer cache since kit definitions change infrequently.
+ * Uses 5-minute cache to balance API load with timely updates.
  *
  * @return array  Flat array of kit objects
  * @throws Exception
@@ -381,7 +381,7 @@ function get_model_hardware_count(int $modelId): int
 function get_kits(): array
 {
     $cacheKey = 'kits_list';
-    $cached = snipeit_cache_get($cacheKey, 86400);
+    $cached = snipeit_cache_get($cacheKey, 300);
     if ($cached !== null) {
         return $cached;
     }
@@ -407,7 +407,7 @@ function get_kit(int $kitId): array
     }
 
     $cacheKey = 'kit_' . $kitId;
-    $cached = snipeit_cache_get($cacheKey, 86400);
+    $cached = snipeit_cache_get($cacheKey, 300);
     if ($cached !== null) {
         return $cached;
     }
@@ -431,7 +431,7 @@ function get_kit_models(int $kitId): array
     }
 
     $cacheKey = 'kit_' . $kitId . '_models';
-    $cached = snipeit_cache_get($cacheKey, 86400);
+    $cached = snipeit_cache_get($cacheKey, 300);
     if ($cached !== null) {
         return $cached;
     }


### PR DESCRIPTION
## Summary
- Kit cache TTL reduced from 86400s (24h) to 300s (5min) across `get_kits()`, `get_kit()`, and `get_kit_models()`
- Kit API calls are lightweight, so 5-minute TTL keeps API load minimal while ensuring Snipe-IT changes propagate quickly

Fixes #73

## Test plan
- [ ] Clear `config/cache/kits_*.json` files
- [ ] Load catalogue kits tab -- kits fetched and cached
- [ ] Reload within 5 minutes -- served from cache
- [ ] Wait >5 minutes or delete cache file -- re-fetched from API

Generated with [Claude Code](https://claude.com/claude-code)