### PR TITLE
Fix overdue check matching wrong user on name collision

### DIFF
--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -347,26 +347,29 @@ function fetch_overdue_assets_for_user(array $lookup, int $snipeUserId): array
 {
     global $pdo;
 
+    // When we have a definitive Snipe-IT user ID, match only on that to avoid
+    // false positives from name collisions between different accounts.
     $where = [];
     $params = [];
     if ($snipeUserId > 0) {
         $where[] = 'assigned_to_id = ?';
         $params[] = $snipeUserId;
-    }
-    if (!empty($lookup['emails'])) {
-        $placeholders = implode(',', array_fill(0, count($lookup['emails']), '?'));
-        $where[] = "(assigned_to_email IS NOT NULL AND LOWER(assigned_to_email) IN ({$placeholders}))";
-        $params = array_merge($params, $lookup['emails']);
-    }
-    if (!empty($lookup['usernames'])) {
-        $placeholders = implode(',', array_fill(0, count($lookup['usernames']), '?'));
-        $where[] = "(assigned_to_username IS NOT NULL AND LOWER(assigned_to_username) IN ({$placeholders}))";
-        $params = array_merge($params, $lookup['usernames']);
-    }
-    if (!empty($lookup['names'])) {
-        $placeholders = implode(',', array_fill(0, count($lookup['names']), '?'));
-        $where[] = "(assigned_to_name IS NOT NULL AND LOWER(assigned_to_name) IN ({$placeholders}))";
-        $params = array_merge($params, $lookup['names']);
+    } else {
+        if (!empty($lookup['emails'])) {
+            $placeholders = implode(',', array_fill(0, count($lookup['emails']), '?'));
+            $where[] = "(assigned_to_email IS NOT NULL AND LOWER(assigned_to_email) IN ({$placeholders}))";
+            $params = array_merge($params, $lookup['emails']);
+        }
+        if (!empty($lookup['usernames'])) {
+            $placeholders = implode(',', array_fill(0, count($lookup['usernames']), '?'));
+            $where[] = "(assigned_to_username IS NOT NULL AND LOWER(assigned_to_username) IN ({$placeholders}))";
+            $params = array_merge($params, $lookup['usernames']);
+        }
+        if (!empty($lookup['names'])) {
+            $placeholders = implode(',', array_fill(0, count($lookup['names']), '?'));
+            $where[] = "(assigned_to_name IS NOT NULL AND LOWER(assigned_to_name) IN ({$placeholders}))";
+            $params = array_merge($params, $lookup['names']);
+        }
     }
 
     if (empty($where)) {


### PR DESCRIPTION
## Summary
- When two Snipe-IT accounts share the same name (e.g. two "Wes Hall" accounts with different emails), the overdue check would match on name and incorrectly block the wrong user from the catalogue
- Fix: when a Snipe-IT user ID is available, use only the ID for the overdue cache lookup. Name/email/username fuzzy matching is now only a fallback when no ID can be resolved

## Root cause
`fetch_overdue_assets_for_user()` used OR logic across all identifiers (ID, email, username, name). A name match on `checked_out_asset_cache` would cross-match between unrelated accounts that happen to share a display name.

## Test plan
- [ ] Log in as a user whose name matches another Snipe-IT user
- [ ] Verify catalogue is not blocked by the other user's overdue items
- [ ] Verify overdue blocking still works for items actually assigned to the logged-in user

Generated with [Claude Code](https://claude.com/claude-code)