### PR TITLE
Fix dashboard user search dropdown hidden behind cards

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -156,8 +156,8 @@ if ($isStaff) {
         <?php if ($isStaff): ?>
 
         <!-- Quick user lookup -->
-        <div class="card mb-3">
-            <div class="card-body">
+        <div class="card mb-3" style="overflow:visible; z-index:10;">
+            <div class="card-body" style="overflow:visible;">
                 <div class="row g-2 align-items-end">
                     <div class="col-md-5">
                         <label class="form-label fw-semibold">Quick user lookup</label>


### PR DESCRIPTION
## Summary
- User search suggestions on the dashboard were rendered behind the status cards below, making results unclickable
- Added `overflow:visible` and `z-index:10` to the search card so the dropdown overlays the content beneath it

## Test plan
- [ ] Open dashboard as staff, type in user search -- suggestions dropdown should render on top of cards below
- [ ] Scroll through results and click any suggestion -- should work regardless of position in the list

Generated with [Claude Code](https://claude.com/claude-code)