### PR TITLE
Pass selected user to quick checkin from dashboard

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -470,6 +470,8 @@ document.addEventListener('DOMContentLoaded', function() {
         showActions();
         if (catEmail) catEmail.value = user.email || '';
         if (catName) catName.value = user.name || user.email || '';
+        var checkinBtn = document.getElementById('dash_btn_checkin');
+        if (checkinBtn && user.id) checkinBtn.href = 'quick_checkin.php?user=' + encodeURIComponent(user.id);
     }
 
     function clearUser() {
@@ -480,6 +482,8 @@ document.addEventListener('DOMContentLoaded', function() {
         input.value = '';
         if (catEmail) catEmail.value = '';
         if (catName) catName.value = '';
+        var checkinBtn = document.getElementById('dash_btn_checkin');
+        if (checkinBtn) checkinBtn.href = 'quick_checkin.php';
     }
 
     input.addEventListener('input', function() {


### PR DESCRIPTION
## Summary
- When staff selects a user on the dashboard and clicks Quick Checkin, the selected user Snipe-IT ID is now passed via ?user= query param
- The existing handler in quick_checkin.php pre-loads the detected user panel and their full checked-out asset list
- Clearing the user on the dashboard resets the link back to the default

## Test plan
- [ ] Select a user on the dashboard who has checked-out assets, click Quick Checkin -- page shows detected user panel with their asset list
- [ ] Clear user on dashboard, click Quick Checkin -- page opens blank
- [ ] On quick_checkin with pre-populated user, click Add on an asset -- it gets added to the checkin list