### PR TITLE
Link Active Checkouts card to checkout history

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -202,12 +202,14 @@ if ($isStaff) {
                 </div>
             </div>
             <div class="col-6 col-md-3">
+                <a href="reservations.php?tab=checkout_history" class="text-decoration-none">
                 <div class="card text-center h-100">
                     <div class="card-body py-3">
                         <div class="fs-3 fw-bold text-info"><?= $activeCount ?></div>
                         <div class="small text-muted">Active Checkouts</div>
                     </div>
                 </div>
+                </a>
             </div>
             <div class="col-6 col-md-3">
                 <div class="card text-center h-100">


### PR DESCRIPTION
## Summary
- Wraps the "Active Checkouts" stat card on the staff dashboard in a link to `reservations.php?tab=checkout_history`
- Closes #65

## Test plan
- [ ] Log in as staff, click the Active Checkouts card on the dashboard → navigates to checkout history tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)