### PR TITLE
Close model history modal on outside click

### DIFF
--- a/src/layout.php
+++ b/src/layout.php
@@ -307,7 +307,7 @@ if (!function_exists('layout_model_history_modal')) {
     {
         ?>
 <div id="modelHistoryBackdrop" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:1050;" onclick="closeModelHistory()"></div>
-<div id="modelHistoryModal" style="display:none; position:fixed; inset:0; z-index:1055; overflow-y:auto; padding:1.75rem;">
+<div id="modelHistoryModal" style="display:none; position:fixed; inset:0; z-index:1055; overflow-y:auto; padding:1.75rem;" onclick="if(event.target===this)closeModelHistory()">
     <div style="max-width:800px; margin:0 auto; background:#fff; border-radius:.5rem; box-shadow:0 .5rem 1rem rgba(0,0,0,.15);">
         <div style="display:flex; align-items:center; justify-content:space-between; padding:.75rem 1rem; border-bottom:1px solid #dee2e6;">
             <h5 id="modelHistoryModalLabel" style="margin:0;">Model History</h5>


### PR DESCRIPTION
## Summary
- Fixes the model history modal not closing when clicking outside the dialog content
- The modal overlay (z-index 1055) covered the backdrop (z-index 1050), so clicks outside the dialog hit the overlay instead of the backdrop onclick handler
- Added `event.target===this` check on the overlay div to close on outside clicks

## Test plan
- [ ] Open model history modal, click outside the white dialog area -> modal closes
- [ ] Click inside the dialog content -> modal stays open

Generated with [Claude Code](https://claude.com/claude-code)