### PR TITLE
Move My Reservations to far right of nav bar

### DIFF
--- a/src/layout.php
+++ b/src/layout.php
@@ -140,11 +140,11 @@ if (!function_exists('layout_render_nav')) {
         $links = [
             ['href' => 'index.php',          'label' => 'Dashboard',           'staff' => false],
             ['href' => 'catalogue.php',      'label' => 'Catalogue',           'staff' => false],
-            ['href' => 'my_bookings.php',    'label' => 'My Reservations',     'staff' => false],
             ['href' => 'reservations.php',   'label' => 'Reservations',        'staff' => true],
             ['href' => 'quick_checkout.php', 'label' => 'Quick Checkout',      'staff' => true],
             ['href' => 'quick_checkin.php',  'label' => 'Quick Checkin',       'staff' => true],
             ['href' => 'activity_log.php',   'label' => 'Admin',               'staff' => false, 'admin_only' => true],
+            ['href' => 'my_bookings.php',    'label' => 'My Reservations',     'staff' => false, 'right' => true],
         ];
 
         $html = '<nav class="app-nav">';
@@ -160,8 +160,9 @@ if (!function_exists('layout_render_nav')) {
             $href    = htmlspecialchars($link['href'], ENT_QUOTES, 'UTF-8');
             $label   = htmlspecialchars($link['label'], ENT_QUOTES, 'UTF-8');
             $classes = 'app-nav-link' . ($active === $link['href'] ? ' active' : '');
+            $style  = !empty($link['right']) ? ' style="margin-left:auto"' : '';
 
-            $html .= '<a href="' . $href . '" class="' . $classes . '">' . $label . '</a>';
+            $html .= '<a href="' . $href . '" class="' . $classes . '"' . $style . '>' . $label . '</a>';
         }
         $html .= '</nav>';
 


### PR DESCRIPTION
## Summary
- Moves My Reservations link to the far right of the nav bar using `margin-left: auto`
- Prevents staff from accidentally clicking My Reservations instead of Reservations, since the staff-only links now sit between them

## Test plan
- [ ] Staff nav shows: Dashboard, Catalogue, Reservations, Quick Checkout, Quick Checkin, Admin ... [gap] ... My Reservations
- [ ] Non-staff nav shows: Dashboard, Catalogue ... [gap] ... My Reservations
- [ ] Mobile collapsed nav still shows all links correctly

Generated with [Claude Code](https://claude.com/claude-code)