### PR TITLE
Preserve catalogue filters when selecting booking user

### DIFF
--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -201,7 +201,8 @@ if ($isStaff && $_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['mode'] ?? '') 
     }
     // Bust cached user groups so auth badges and permissions refresh immediately
     unset($_SESSION['snipeit_user_groups']);
-    header('Location: catalogue.php');
+    $qs = $_SERVER['QUERY_STRING'] ?? '';
+    header('Location: catalogue.php' . ($qs !== '' ? '?' . $qs : ''));
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Booking user selection redirect now preserves the query string (search, category, sort, page, date filters)
- Previously, selecting a user or clearing the selection redirected to bare `catalogue.php`, wiping all filters

Fixes #89

## Test plan
- [ ] Search for an item in the catalogue, then select a booking user — search field stays
- [ ] Verify category, sort, and date filters also persist after user selection
- [ ] Click "Clear selected user" — filters still preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)