### PR TITLE
Block quick checkout when validation errors exist

### DIFF
--- a/public/quick_checkout.php
+++ b/public/quick_checkout.php
@@ -360,7 +360,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                     if (!empty($reservationConflicts) && !$overrideAllowed) {
                         $errors[] = 'Some assets are reserved for this time. Review who reserved them below or tick "Override" to proceed anyway.';
-                    } else {
+                    }
+
+                    if (empty($errors)) {
                         $expectedCheckinIso = $endDt->setTimezone($utc)->format('Y-m-d H:i:s');
 
                         foreach ($checkoutAssets as $asset) {


### PR DESCRIPTION
## Summary
- Quick checkout proceeded even when single active checkout or other validation checks added errors, because the code only gated on reservation conflicts
- Changed `} else {` to a separate `if (empty($errors))` check so no checkout happens when any prior validation fails

## Test plan
- [ ] Enable single active checkout, try quick checkout for a user with items out — checkout is blocked (red error, no green success)
- [ ] Checkout with no errors still works normally
- [ ] Reservation conflict override still works

Generated with [Claude Code](https://claude.com/claude-code)