### PR TITLE
Add config toggles for quick checkout warnings

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -146,6 +146,12 @@ return [
         'allowed_categories' => [],
     ],
 
+    'quick_checkout' => [
+        'warn_access_group'  => true,  // warn when user lacks an Access group
+        'warn_opening_hours' => true,  // warn when dates fall outside opening hours
+        'warn_overdue'       => true,  // warn when user has overdue items
+    ],
+
     'checkout_limits' => [
         'enabled' => false,  // master switch; false = no restrictions (backwards compatible)
         'default' => [


### PR DESCRIPTION
## Summary
- New `quick_checkout` config section with three toggles:
  - `warn_access_group` — warn when user lacks an Access group
  - `warn_opening_hours` — warn when dates fall outside opening hours
  - `warn_overdue` — warn when user has overdue items
- All default to `true` for backwards compatibility
- Set any to `false` to suppress that warning

## Test plan
- [ ] With all three `true` (or config key missing) — all warnings show as before
- [ ] Set `warn_opening_hours` to `false` — opening hours warning suppressed, others still show
- [ ] Set all three to `false` — no bypass warnings shown

Generated with [Claude Code](https://claude.com/claude-code)