### PR TITLE
Add toggle to enable/disable Quick Checkout tab

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -134,6 +134,7 @@ return [
         'overdue_staff_email' => '', // overdue report recipients (comma/newline separated)
         'overdue_staff_name'  => '', // optional names for recipients (comma/newline separated)
         'block_catalogue_overdue' => true, // block catalogue for users with overdue checkouts
+        'quick_checkout_enabled' => true, // show the Quick Checkout tab for staff
     ],
 
     'reservations' => [

--- a/public/quick_checkout.php
+++ b/public/quick_checkout.php
@@ -12,6 +12,12 @@ require_once SRC_PATH . '/email.php';
 require_once SRC_PATH . '/layout.php';
 require_once SRC_PATH . '/opening_hours.php';
 
+$qcConfig = load_config();
+if (!($qcConfig['app']['quick_checkout_enabled'] ?? true)) {
+    header('Location: index.php');
+    exit;
+}
+
 $appTz = app_get_timezone();
 $now = new DateTime('now', $appTz);
 $defaultStart = $now->format('Y-m-d\TH:i');

--- a/public/settings.php
+++ b/public/settings.php
@@ -386,6 +386,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $app['overdue_staff_email']   = $post('app_overdue_staff_email', $app['overdue_staff_email'] ?? '');
     $app['overdue_staff_name']    = $post('app_overdue_staff_name', $app['overdue_staff_name'] ?? '');
     $app['block_catalogue_overdue'] = isset($_POST['app_block_catalogue_overdue']);
+    $app['quick_checkout_enabled'] = isset($_POST['app_quick_checkout_enabled']);
 
     $catalogue = $config['catalogue'] ?? [];
     $allowedRaw = $_POST['catalogue_allowed_categories'] ?? [];
@@ -1135,6 +1136,23 @@ $allowedCategoryIds = array_map('intval', $allowedCategoryIds);
                                 </div>
                                 <div class="form-text mt-1">
                                     When enabled, users with overdue assets cannot access the catalogue until items are returned.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mt-2">
+                            <div class="col-12">
+                                <div class="form-check">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           name="app_quick_checkout_enabled"
+                                           id="app_quick_checkout_enabled"
+                                        <?= $cfg(['app', 'quick_checkout_enabled'], true) ? 'checked' : '' ?>>
+                                    <label class="form-check-label fw-semibold" for="app_quick_checkout_enabled">
+                                        Enable Quick Checkout
+                                    </label>
+                                </div>
+                                <div class="form-text mt-1">
+                                    Show the Quick Checkout tab for staff. When disabled, the page is hidden and direct access redirects to the dashboard.
                                 </div>
                             </div>
                         </div>

--- a/src/layout.php
+++ b/src/layout.php
@@ -137,11 +137,14 @@ if (!function_exists('layout_render_nav')) {
      */
     function layout_render_nav(string $active, bool $isStaff, bool $isAdmin = false): string
     {
+        $cfg = load_config();
+        $quickCheckoutEnabled = $cfg['app']['quick_checkout_enabled'] ?? true;
+
         $links = [
             ['href' => 'index.php',          'label' => 'Dashboard',           'staff' => false],
             ['href' => 'catalogue.php',      'label' => 'Catalogue',           'staff' => false],
             ['href' => 'reservations.php',   'label' => 'Reservations',        'staff' => true],
-            ['href' => 'quick_checkout.php', 'label' => 'Quick Checkout',      'staff' => true],
+            ['href' => 'quick_checkout.php', 'label' => 'Quick Checkout',      'staff' => true, 'enabled' => $quickCheckoutEnabled],
             ['href' => 'quick_checkin.php',  'label' => 'Quick Checkin',       'staff' => true],
             ['href' => 'activity_log.php',   'label' => 'Admin',               'staff' => false, 'admin_only' => true],
             ['href' => 'my_bookings.php',    'label' => 'My Reservations',     'staff' => false, 'right' => true],
@@ -149,6 +152,9 @@ if (!function_exists('layout_render_nav')) {
 
         $html = '<nav class="app-nav">';
         foreach ($links as $link) {
+            if (isset($link['enabled']) && !$link['enabled']) {
+                continue;
+            }
             if (!empty($link['admin_only'])) {
                 if (!$isAdmin) {
                     continue;


### PR DESCRIPTION
## Summary
- New `app.quick_checkout_enabled` config key (defaults to `true`)
- When disabled: nav link hidden, direct URL access redirects to dashboard
- Checkbox added to admin settings under the App section

## Changes
- `config/config.example.php` — new `quick_checkout_enabled` key
- `src/layout.php` — nav skips links with `enabled => false`
- `public/quick_checkout.php` — redirects to dashboard when disabled
- `public/settings.php` — checkbox + POST handler

## Test plan
- [ ] Default (key missing or `true`) — Quick Checkout tab visible and works
- [ ] Uncheck in settings — tab disappears from nav
- [ ] Direct URL `/quick_checkout.php` when disabled — redirects to dashboard
- [ ] Re-enable — tab reappears

Generated with [Claude Code](https://claude.com/claude-code)