### PR TITLE
Fix user search dropdown click race on quick checkout

### DIFF
--- a/public/quick_checkout.php
+++ b/public/quick_checkout.php
@@ -713,7 +713,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     Check out to (Snipe-IT user email or name)
                                 </label>
                                 <div class="position-relative user-autocomplete-wrapper">
-                                    <input type="text"
+                                    <input type="search"
                                            name="checkout_to"
                                            class="form-control user-autocomplete"
                                            autocomplete="off"
@@ -876,7 +876,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     btn.appendChild(secondary);
                 }
 
-                btn.addEventListener('click', () => {
+                btn.addEventListener('mousedown', (e) => {
+                    e.preventDefault();
                     input.value = btn.dataset.value;
                     hideSuggestions();
                     input.focus();
@@ -951,7 +952,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 btn.textContent = label;
                 btn.dataset.value = value;
 
-                btn.addEventListener('click', () => {
+                btn.addEventListener('mousedown', (e) => {
+                    e.preventDefault();
                     input.value = btn.dataset.value;
                     hideSuggestions();
                     input.focus();


### PR DESCRIPTION
## Summary
- Suggestion buttons used `click` which fires after `blur`, so the 150ms blur timeout hid the dropdown before the click registered
- Changed to `mousedown` + `preventDefault()` on both user and asset suggestion buttons (same fix as catalogue page)
- Changed user input from `type="text"` to `type="search"` to reduce browser autofill/login suggestion interference

Fixes #96

## Test plan
- [ ] Search for a user on quick checkout — clicking a suggestion reliably selects it
- [ ] Asset search suggestions also clickable without issues
- [ ] Browser no longer shows login/autofill overlay on the user field

Generated with [Claude Code](https://claude.com/claude-code)