### PR TITLE
Clear booking user after reservation submit

### DIFF
--- a/public/basket_checkout.php
+++ b/public/basket_checkout.php
@@ -244,6 +244,7 @@ try {
     $pdo->commit();
     $_SESSION['basket'] = []; // clear basket
     unset($_SESSION['basket_kit_groups'], $_SESSION['basket_kit_names']);
+    unset($_SESSION['booking_user_override']);
 
     activity_log_event('reservation_submitted', 'Reservation submitted', [
         'subject_type' => 'reservation',

--- a/public/book_submit.php
+++ b/public/book_submit.php
@@ -103,6 +103,7 @@ $insert->execute([
 ]);
 
 $reservationId = (int)$pdo->lastInsertId();
+unset($_SESSION['booking_user_override']);
 activity_log_event('reservation_submitted', 'Reservation submitted', [
     'subject_type' => 'reservation',
     'subject_id'   => $reservationId,


### PR DESCRIPTION
## Summary
- `booking_user_override` session key was never cleared after a successful reservation, so the next booking would target the previous user
- Now cleared in both `basket_checkout.php` (multi-item reservation) and `book_submit.php` (single-item legacy flow)

Fixes #97

## Test plan
- [ ] As staff, select a user, submit a reservation — return to catalogue, booking user is cleared
- [ ] Same flow via basket checkout — booking user cleared after submit
- [ ] Non-staff users unaffected (no override to clear)

Generated with [Claude Code](https://claude.com/claude-code)