### PR TITLE
Add detected checkin user to note for unchecked-out assets

### DIFF
--- a/public/quick_checkin.php
+++ b/public/quick_checkin.php
@@ -244,7 +244,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                     if (!$isCheckedOut) {
                         // Asset is not currently checked out — add a note to its history instead of failing
-                        $noteText = 'Asset returned via quick check-in by ' . $staffDisplayName . '. Asset was not checked out at the time.';
+                        $noteText = 'Asset returned via quick check-in by ' . $staffDisplayName . '.';
+                        $detectedUser = $_SESSION['quick_checkin_detected_user'] ?? null;
+                        if ($detectedUser) {
+                            $noteText .= ' Checkin user: ' . $detectedUser['name'] . ' (' . $detectedUser['email'] . ').';
+                        }
+                        $noteText .= ' Asset was not checked out at the time.';
                         if ($note !== '') {
                             $noteText .= ' Staff note: ' . $note;
                         }


### PR DESCRIPTION
## Summary
- When an asset is not checked out during quick checkin, the note now includes the detected checkin user's name and email (from the session) so staff know who was returning equipment

Closes #100

## Test plan
- Scan assets into quick checkin where one asset is not currently checked out in Snipe-IT
- Submit checkin
- Check Snipe-IT activity log for the unchecked-out asset — note should include the detected user's name and email
- Repeat without a detected user (scan an asset that doesn't belong to anyone) — note should omit the user line

🤖 Generated with [Claude Code](https://claude.com/claude-code)