### PR TITLE
Track last login time in local users table

### DIFF
--- a/public/install/schema.sql
+++ b/public/install/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_login_at DATETIME DEFAULT NULL,
 
     PRIMARY KEY (id),
     UNIQUE KEY uq_users_user_id (user_id),

--- a/public/install/upgrade/v1.3.0.sql
+++ b/public/install/upgrade/v1.3.0.sql
@@ -1,0 +1,7 @@
+-- Upgrade v1.3.0: Track last login time for users
+
+ALTER TABLE users
+    ADD COLUMN last_login_at DATETIME DEFAULT NULL AFTER created_at;
+
+INSERT IGNORE INTO schema_version (version)
+VALUES ('v1.3.0');

--- a/public/login_process.php
+++ b/public/login_process.php
@@ -102,7 +102,7 @@ $upsertUser = static function (PDO $pdo, string $email, string $fullName): int {
     if ($existing) {
         $update = $pdo->prepare("
             UPDATE {$userTable}
-               SET name = :name
+               SET name = :name, last_login_at = NOW()
              WHERE id = :id
         ");
         $update->execute([
@@ -114,8 +114,8 @@ $upsertUser = static function (PDO $pdo, string $email, string $fullName): int {
 
     $userIdHex = sprintf('%u', crc32(strtolower($email)));
     $insert = $pdo->prepare("
-        INSERT INTO {$userTable} ({$userIdCol}, name, email, created_at)
-        VALUES (:user_id, :name, :email, NOW())
+        INSERT INTO {$userTable} ({$userIdCol}, name, email, created_at, last_login_at)
+        VALUES (:user_id, :name, :email, NOW(), NOW())
     ");
     $insert->execute([
         ':user_id' => $userIdHex,


### PR DESCRIPTION
## Summary
- Adds `last_login_at` column to the `users` table
- Set to `NOW()` on every login (both new user creation and returning user update)
- Migration: `v1.3.0.sql`

## Test plan
- Run the v1.3.0 migration on an existing database
- Log in — verify `last_login_at` is populated in the `users` row
- Log out and back in — verify `last_login_at` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)