### PR TITLE
Fix catalogue pagination losing active tab

### DIFF
--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -1420,6 +1420,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                     <ul class="pagination">
                         <?php
                         $baseQuery = [
+                            'tab'      => $tab,
                             'q'        => $searchRaw,
                             'category' => $categoryRaw,
                             'sort'     => $sortRaw,


### PR DESCRIPTION
## Summary
- Adds `tab` param to catalogue pagination `$baseQuery` so page 2+ links stay on the equipment tab instead of resetting to the default kits tab

## Test plan
- [ ] Go to catalogue equipment tab, verify page 2 link includes `tab=equipment`
- [ ] Verify kits tab pagination (if present) also preserves `tab=kits`

🤖 Generated with [Claude Code](https://claude.com/claude-code)