### PR TITLE
Remove login requirement from upgrade page

### DIFF
--- a/public/install/upgrade/index.php
+++ b/public/install/upgrade/index.php
@@ -1,18 +1,12 @@
 <?php
 require_once __DIR__ . '/../../../src/bootstrap.php';
-if (!defined('AUTH_LOGIN_PATH')) {
-    define('AUTH_LOGIN_PATH', '../../login.php');
-}
-require_once SRC_PATH . '/auth.php';
 require_once SRC_PATH . '/db.php';
 require_once SRC_PATH . '/layout.php';
 require_once SRC_PATH . '/config_writer.php';
 
-$isAdmin = !empty($currentUser['is_admin']);
-if (!$isAdmin) {
-    http_response_code(403);
-    echo 'Access denied.';
-    exit;
+// h() is normally provided by auth.php — define a fallback
+if (!function_exists('h')) {
+    function h(?string $s): string { return htmlspecialchars($s ?? '', ENT_QUOTES, 'UTF-8'); }
 }
 
 $versionFile = APP_ROOT . '/version.txt';


### PR DESCRIPTION
## Summary
- Remove auth.php requirement from `install/upgrade/index.php` so upgrades can run without logging in
- Make `login_process.php` check for `last_login_at` column before using it, so login works on pre-v1.3.0 schemas

Fixes the chicken-and-egg problem where login fails on old schemas because the `last_login_at` column doesn't exist yet, but the upgrade page requires login.

## Test plan
- [ ] Access `/install/upgrade/` without being logged in — page loads and shows pending upgrades
- [ ] Run upgrades successfully from the unauthenticated page
- [ ] Login works on a database that hasn't had v1.3.0 migration applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)