### PR TITLE
Add model thumbnails to basket

### DIFF
--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -286,6 +286,13 @@ input[type="checkbox"] {
     background: rgba(var(--primary-rgb), 0.04);
 }
 
+.basket-thumb {
+    width: 48px;
+    height: 48px;
+    object-fit: contain;
+    border-radius: 0.35rem;
+}
+
 .badge-summary {
     display: inline-block;
     padding: 0.25rem 0.75rem;

--- a/public/basket.php
+++ b/public/basket.php
@@ -410,6 +410,7 @@ if (!empty($basket)) {
                 <table class="table table-striped table-bookings align-middle">
                     <thead>
                         <tr>
+                            <th style="width:60px"></th>
                             <th>Model</th>
                             <th>Manufacturer</th>
                             <th>Category</th>
@@ -425,7 +426,7 @@ if (!empty($basket)) {
                             $kName = $kitNames[$kid] ?? ('Kit #' . $kid);
                     ?>
                         <tr class="table-info">
-                            <td colspan="5">
+                            <td colspan="6">
                                 <strong><?= h($kName) ?></strong>
                                 <span class="text-muted small">(kit)</span>
                             </td>
@@ -459,7 +460,16 @@ if (!empty($basket)) {
                                 }
                             }
                         ?>
+                        <?php
+                            $imgPath = $model['image'] ?? '';
+                            $imgSrc = $imgPath !== '' ? 'image_proxy.php?src=' . urlencode($imgPath) : '';
+                        ?>
                         <tr>
+                            <td>
+                                <?php if ($imgSrc !== ''): ?>
+                                    <img src="<?= h($imgSrc) ?>" alt="" class="basket-thumb">
+                                <?php endif; ?>
+                            </td>
                             <td class="ps-4"><?= h($model['name'] ?? 'Model') ?></td>
                             <td><?= h($model['manufacturer']['name'] ?? '') ?></td>
                             <td><?= h($model['category']['name'] ?? '') ?></td>
@@ -499,7 +509,16 @@ if (!empty($basket)) {
                                 }
                             }
                     ?>
+                        <?php
+                            $imgPath = $model['image'] ?? '';
+                            $imgSrc = $imgPath !== '' ? 'image_proxy.php?src=' . urlencode($imgPath) : '';
+                        ?>
                         <tr>
+                            <td>
+                                <?php if ($imgSrc !== ''): ?>
+                                    <img src="<?= h($imgSrc) ?>" alt="" class="basket-thumb">
+                                <?php endif; ?>
+                            </td>
                             <td><?= h($model['name'] ?? 'Model') ?></td>
                             <td><?= h($model['manufacturer']['name'] ?? '') ?></td>
                             <td><?= h($model['category']['name'] ?? '') ?></td>


### PR DESCRIPTION
## Summary
- Add thumbnail image column to the basket items table
- Images proxied through `image_proxy.php` (same as catalogue)
- 48x48px with `object-fit: contain` for consistent sizing

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)