### PR TITLE
Fix kit bottleneck message when all items unavailable

### DIFF
--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -1757,7 +1757,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                                     <strong><?= $windowActive ? 'Kits available for selected dates:' : 'Kits available now:' ?></strong>
                                     <?= (int)$kitCard['availability'] ?>
                                     <?php if ($kitCard['availability'] <= 0 && $kitCard['bottleneck']): ?>
-                                        <span class="text-danger">(limited by <?= h($kitCard['bottleneck']) ?>)</span>
+                                        <span class="text-danger"><?php if ($kitCard['any_available']): ?>(limited by <?= h($kitCard['bottleneck']) ?>)<?php else: ?>(no items available)<?php endif; ?></span>
                                     <?php endif; ?>
                                 </p>
                                 <?php if (!empty($kitCard['certs'])): ?>


### PR DESCRIPTION
## Summary
- When all models in a kit have 0 availability, show "(no items available)" instead of "(limited by Model X)"
- "Limited by" message now only appears when a specific model is the true bottleneck (some other items still have stock)

## Test plan
- [ ] Kit with all items at 0: shows "(no items available)"
- [ ] Kit with one model at 0 but others available: shows "(limited by Model X)" with partial-add UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)