### PR TITLE
Don't auto-overwrite end time after manual selection

### DIFF
--- a/public/basket.php
+++ b/public/basket.php
@@ -638,6 +638,8 @@ document.addEventListener('DOMContentLoaded', function () {
             + 'T' + pad(d.getHours()) + ':' + pad(d.getMinutes());
     }
 
+    var endManuallySet = false;
+
     var startPicker = new SlotPicker({
         container: document.getElementById('start-slot-picker'),
         hiddenInput: document.getElementById('post-start-datetime'),
@@ -648,6 +650,7 @@ document.addEventListener('DOMContentLoaded', function () {
         timeFormat: <?= json_encode(app_get_time_format()) ?>,
         dateFormat: <?= json_encode(app_get_date_format()) ?>,
         onSelect: function (datetime) {
+            if (endManuallySet) return;
             // Auto-set end picker default based on max checkout hours
             if (maxCheckoutHours > 0) {
                 var startMs = Date.parse(datetime);
@@ -680,6 +683,7 @@ document.addEventListener('DOMContentLoaded', function () {
         timeFormat: <?= json_encode(app_get_time_format()) ?>,
         dateFormat: <?= json_encode(app_get_date_format()) ?>,
         onSelect: function (datetime) {
+            endManuallySet = true;
             // When both have values, redirect to check availability
             var startVal = document.getElementById('post-start-datetime').value;
             if (startVal) {
@@ -698,6 +702,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     if (existingEnd) {
         endPicker.setValue(existingEnd);
+        endManuallySet = true;
     }
 
     // Bypass toggles

--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -1910,6 +1910,9 @@ document.addEventListener('DOMContentLoaded', function () {
         dateFormat: <?= json_encode(app_get_date_format()) ?>
     };
 
+    var equipEndManuallySet = false;
+    var kitsEndManuallySet = false;
+
     function autoSetEnd(endPicker, datetime) {
         if (maxCheckoutHours > 0) {
             var ms = Date.parse(datetime);
@@ -1940,17 +1943,17 @@ document.addEventListener('DOMContentLoaded', function () {
             hiddenInput: equipEndHidden,
             type: 'end',
             intervalMinutes: intervalMinutes,
-            onSelect: function () { if (equipStartHidden.value) submitWindowForm(equipForm); }
+            onSelect: function () { equipEndManuallySet = true; if (equipStartHidden.value) submitWindowForm(equipForm); }
         }));
         equipStartPicker = new SlotPicker(Object.assign({}, spOpts, {
             container: document.getElementById('equip-start-picker'),
             hiddenInput: equipStartHidden,
             type: 'start',
             intervalMinutes: intervalMinutes,
-            onSelect: function (dt) { autoSetEnd(equipEndPicker, dt); }
+            onSelect: function (dt) { if (!equipEndManuallySet) autoSetEnd(equipEndPicker, dt); }
         }));
         if (equipStartHidden.value) equipStartPicker.setValue(equipStartHidden.value);
-        if (equipEndHidden.value) equipEndPicker.setValue(equipEndHidden.value);
+        if (equipEndHidden.value) { equipEndPicker.setValue(equipEndHidden.value); equipEndManuallySet = true; }
     }
 
     // ---- Kits tab slot pickers ----
@@ -1965,17 +1968,17 @@ document.addEventListener('DOMContentLoaded', function () {
             hiddenInput: kitsEndHidden,
             type: 'end',
             intervalMinutes: intervalMinutes,
-            onSelect: function () { if (kitsStartHidden.value) submitWindowForm(kitsForm); }
+            onSelect: function () { kitsEndManuallySet = true; if (kitsStartHidden.value) submitWindowForm(kitsForm); }
         }));
         kitsStartPicker = new SlotPicker(Object.assign({}, spOpts, {
             container: document.getElementById('kits-start-picker'),
             hiddenInput: kitsStartHidden,
             type: 'start',
             intervalMinutes: intervalMinutes,
-            onSelect: function (dt) { autoSetEnd(kitsEndPicker, dt); }
+            onSelect: function (dt) { if (!kitsEndManuallySet) autoSetEnd(kitsEndPicker, dt); }
         }));
         if (kitsStartHidden.value) kitsStartPicker.setValue(kitsStartHidden.value);
-        if (kitsEndHidden.value) kitsEndPicker.setValue(kitsEndHidden.value);
+        if (kitsEndHidden.value) { kitsEndPicker.setValue(kitsEndHidden.value); kitsEndManuallySet = true; }
     }
 
     // ---- Today buttons ----
@@ -1990,10 +1993,10 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     if (todayBtn && equipStartPicker) {
-        todayBtn.addEventListener('click', function () { handleToday(equipStartPicker, equipEndPicker, equipForm); });
+        todayBtn.addEventListener('click', function () { equipEndManuallySet = false; handleToday(equipStartPicker, equipEndPicker, equipForm); });
     }
     if (kitsTodayBtn && kitsStartPicker) {
-        kitsTodayBtn.addEventListener('click', function () { handleToday(kitsStartPicker, kitsEndPicker, kitsForm); });
+        kitsTodayBtn.addEventListener('click', function () { kitsEndManuallySet = false; handleToday(kitsStartPicker, kitsEndPicker, kitsForm); });
     }
 
     // ---- Bypass toggles ----

--- a/public/reservation_edit.php
+++ b/public/reservation_edit.php
@@ -846,6 +846,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             + 'T' + pad(d.getHours()) + ':' + pad(d.getMinutes());
     }
 
+    var endManuallySet = false;
+
     var startPicker = new SlotPicker({
         container: document.getElementById('edit-start-picker'),
         hiddenInput: document.getElementById('edit-start-datetime'),
@@ -856,6 +858,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         timeFormat: <?= json_encode(app_get_time_format()) ?>,
         dateFormat: <?= json_encode(app_get_date_format()) ?>,
         onSelect: function (datetime) {
+            if (endManuallySet) return;
             if (maxCheckoutHours > 0) {
                 var startMs = Date.parse(datetime);
                 if (!isNaN(startMs)) {
@@ -884,14 +887,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         isStaff: <?= $isStaff ? 'true' : 'false' ?>,
         isAdmin: <?= $isAdmin ? 'true' : 'false' ?>,
         timeFormat: <?= json_encode(app_get_time_format()) ?>,
-        dateFormat: <?= json_encode(app_get_date_format()) ?>
+        dateFormat: <?= json_encode(app_get_date_format()) ?>,
+        onSelect: function () { endManuallySet = true; }
     });
 
     // Restore selection from hidden inputs (initial load or POST failure re-render)
     var existingStart = document.getElementById('edit-start-datetime').value;
     var existingEnd = document.getElementById('edit-end-datetime').value;
     if (existingStart) { startPicker.setValue(existingStart); }
-    if (existingEnd) { endPicker.setValue(existingEnd); }
+    if (existingEnd) { endPicker.setValue(existingEnd); endManuallySet = true; }
 
     // Bypass toggles
     var capToggle = document.getElementById('bypass-capacity');


### PR DESCRIPTION
## Summary
- Start picker onSelect was unconditionally auto-setting the end picker every time the start changed, even if the user had already manually set an end time.
- Added endManuallySet flag across basket, catalogue (both tabs), and reservation edit pages.
- Auto-default only fires on the first start selection before the user has touched the end picker.
- Restored values on page reload also set the flag (since they represent a prior selection).
- Today buttons reset the flag so both pickers get fresh defaults.

## Test plan
- [ ] Fresh basket: pick start then end auto-sets. Pick end manually then change start and end does NOT change.
- [ ] Catalogue: same behavior on both equipment and kits tabs
- [ ] Catalogue Today button still auto-sets both start and end
- [ ] Reservation edit: existing values load, changing start does NOT overwrite end
- [ ] Page reload preserves end (flag is set on restore)

Generated with [Claude Code](https://claude.com/claude-code)