### PR TITLE
Batch-fetch reservation items to fix slow page loads

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -72,6 +72,12 @@ if ($isStaff) {
     $pendingPickups = $stmt->fetchAll(PDO::FETCH_ASSOC);
     $pendingCount   = count($pendingPickups);
 
+    // Batch-fetch all reservation items for pending pickups (no API calls)
+    $pendingResItems = [];
+    if (!empty($pendingPickups)) {
+        $pendingResItems = batch_get_reservation_items($pdo, array_column($pendingPickups, 'id'));
+    }
+
     // Active checkouts count
     $activeCount = (int) $pdo->query("SELECT COUNT(*) FROM checkouts WHERE status IN ('open','partial')")->fetchColumn();
 
@@ -253,7 +259,7 @@ if ($isStaff) {
                                 <tbody>
                                     <?php foreach ($pendingPickups as $pickup): ?>
                                         <?php
-                                            $items = get_reservation_items_with_names($pdo, (int)$pickup['id']);
+                                            $items = $pendingResItems[(int)$pickup['id']] ?? [];
                                             $summary = build_items_summary_text($items);
                                         ?>
                                         <tr>

--- a/public/staff_reservations.php
+++ b/public/staff_reservations.php
@@ -254,6 +254,12 @@ try {
     $totalRows = 0;
     $totalPages = 1;
 }
+
+// Batch-fetch all reservation items in one query (no API calls)
+$allResItems = [];
+if (!empty($reservations)) {
+    $allResItems = batch_get_reservation_items($pdo, array_column($reservations, 'id'));
+}
 ?>
 <?php if (!$embedded): ?>
 <!DOCTYPE html>
@@ -420,7 +426,7 @@ try {
                     <tbody>
                         <?php foreach ($reservations as $r): ?>
                             <?php
-                                $items      = get_reservation_items_with_names($pdo, (int)$r['id']);
+                                $items      = $allResItems[(int)$r['id']] ?? [];
                                 $itemsLines = [];
                                 foreach ($items as $item) {
                                     $name = $item['name'] ?? '';


### PR DESCRIPTION
## Summary

- Adds `batch_get_reservation_items()` to `src/booking_helpers.php` — runs a single `SELECT ... WHERE reservation_id IN (...)` query using `model_name_cache`, returning items grouped by reservation ID
- Replaces per-row `get_reservation_items_with_names()` calls (N+1 pattern) with the batch function in `staff_reservations.php`, `my_bookings.php`, and `index.php`
- Eliminates all Snipe-IT API round-trips from reservation list rendering

| Metric | Before (10 rows) | After |
|--------|-------------------|-------|
| DB queries | ~12 | 1 batch |
| Snipe-IT API calls | 20-30 | 0 |

Existing `get_reservation_items_with_names()` is unchanged for call sites that need the `image` field (e.g., `staff_checkout.php`).

## Test plan

- [ ] Load `reservations.php?tab=history` — same content, noticeably faster
- [ ] Load `my_bookings.php` — upcoming and past reservations show correct items/quantities
- [ ] Load `index.php` (dashboard) — pending pickups table shows correct item summaries
- [ ] Verify item names match what Snipe-IT shows for each model

🤖 Generated with [Claude Code](https://claude.com/claude-code)