### PR TITLE
Fix ownership checks to use snipeit_user_id

### DIFF
--- a/public/delete_reservation.php
+++ b/public/delete_reservation.php
@@ -26,7 +26,7 @@ if ($resId <= 0) {
 
 // Load reservation to check ownership
 $stmt = $pdo->prepare("
-    SELECT id, user_id, status
+    SELECT id, user_id, snipeit_user_id, status
     FROM reservations
     WHERE id = :id
     LIMIT 1
@@ -40,9 +40,10 @@ if (!$reservation) {
     exit;
 }
 
-$ownsReservation = $currentUserId !== ''
-    && isset($reservation['user_id'])
-    && (string)$reservation['user_id'] === $currentUserId;
+$currentSnipeId = (string)($currentUser['snipeit_user_id'] ?? '');
+$ownsReservation = $currentSnipeId !== ''
+    && isset($reservation['snipeit_user_id'])
+    && (string)$reservation['snipeit_user_id'] === $currentSnipeId;
 
 if (!$isStaff && !$ownsReservation) {
     http_response_code(403);

--- a/public/reservation_edit.php
+++ b/public/reservation_edit.php
@@ -117,8 +117,9 @@ if (!$reservation) {
 }
 
 if (!$isStaff) {
-    $reservationUserId = (string)($reservation['user_id'] ?? '');
-    if ($reservationUserId === '' || $reservationUserId !== $currentUserId) {
+    $currentSnipeId = (string)($currentUser['snipeit_user_id'] ?? '');
+    $resSnipeId     = (string)($reservation['snipeit_user_id'] ?? '');
+    if ($currentSnipeId === '' || $resSnipeId !== $currentSnipeId) {
         http_response_code(403);
         echo 'Access denied.';
         exit;


### PR DESCRIPTION
## Summary

- `delete_reservation.php` and `reservation_edit.php` were comparing against the legacy `user_id` column instead of `snipeit_user_id` for ownership checks
- Non-staff users could be incorrectly denied (or granted) access to edit/delete their own reservations

## Test plan

- [ ] As a non-staff user, delete your own reservation — should succeed
- [ ] As a non-staff user, try to delete another user's reservation — should get 403
- [ ] As a non-staff user, edit your own pending reservation — should succeed
- [ ] As a non-staff user, try to edit another user's reservation — should get 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)