### PR TITLE
Fix model history modal on embedded checkout history tab

### DIFF
--- a/public/checkout_history.php
+++ b/public/checkout_history.php
@@ -449,6 +449,7 @@ foreach ($checkouts as $co) {
 </html>
 <?php endif; ?>
 <?php if ($embedded): ?>
+<?php if ($isStaff) { layout_model_history_modal(); } ?>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     var form = document.getElementById('checkout-history-filter-form');


### PR DESCRIPTION
## Summary

- Clicking an asset model name on `reservations.php?tab=checkout_history` did nothing — the modal never appeared
- Root cause: `layout_model_history_modal()` was only called in the standalone (`!$embedded`) code path, so the modal markup and JS were missing when the tab was embedded in `reservations.php`
- Added the `layout_model_history_modal()` call to the embedded path

## Test plan

- [ ] Go to `reservations.php?tab=checkout_history` — click a model name — modal should open with checkout history
- [ ] Go to `checkout_history.php` directly (standalone) — modal should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)