### PR TITLE
Add reservation name field to booking workflow

### DIFF
--- a/public/basket.php
+++ b/public/basket.php
@@ -607,6 +607,15 @@ if (!empty($basket)) {
                 <input type="hidden" name="end_datetime" id="post-end-datetime"
                        value="<?= htmlspecialchars($previewEndRaw) ?>">
 
+                <div class="mb-3">
+                    <label for="reservation-name" class="form-label fw-semibold">
+                        Reservation name<?= $isStaff ? ' <span class="text-muted fw-normal">(optional)</span>' : '' ?>
+                    </label>
+                    <input type="text" class="form-control" id="reservation-name" name="reservation_name"
+                           placeholder="e.g. Studio A shoot" maxlength="255"
+                           <?= $isStaff ? '' : 'required' ?>>
+                </div>
+
                 <p class="mb-2 text-muted">
                     When you click <strong>Confirm booking</strong>, the system will re-check availability
                     and reject the booking if another user has taken items in the meantime.

--- a/public/basket_checkout.php
+++ b/public/basket_checkout.php
@@ -26,6 +26,15 @@ if (empty($basket)) {
 $startRaw = $_POST['start_datetime'] ?? '';
 $endRaw   = $_POST['end_datetime'] ?? '';
 
+$isStaff = !empty($currentUser['is_staff']) || !empty($currentUser['is_admin']);
+$reservationName = trim($_POST['reservation_name'] ?? '');
+if ($reservationName === '') {
+    $reservationName = null;
+}
+if (!$isStaff && $reservationName === null) {
+    basket_error('Reservation name is required.');
+}
+
 if (!$startRaw || !$endRaw) {
     basket_error('Start and end date/time are required.');
 }
@@ -204,11 +213,11 @@ try {
         INSERT INTO reservations (
             user_name, user_email, user_id, snipeit_user_id,
             asset_id, asset_name_cache,
-            start_datetime, end_datetime, status
+            start_datetime, end_datetime, status, name
         ) VALUES (
             :user_name, :user_email, :user_id, :snipeit_user_id,
             0, :asset_name_cache,
-            :start_datetime, :end_datetime, 'pending'
+            :start_datetime, :end_datetime, 'pending', :name
         )
     ");
     $insertRes->execute([
@@ -219,6 +228,7 @@ try {
         ':asset_name_cache' => 'Pending checkout',
         ':start_datetime'   => $start,
         ':end_datetime'     => $end,
+        ':name'             => $reservationName,
     ]);
 
     $reservationId = (int)$pdo->lastInsertId();

--- a/public/index.php
+++ b/public/index.php
@@ -263,7 +263,12 @@ if ($isStaff) {
                                             $summary = build_items_summary_text($items);
                                         ?>
                                         <tr>
-                                            <td><?= h($pickup['user_name']) ?></td>
+                                            <td>
+                                                <?= h($pickup['user_name']) ?>
+                                                <?php if (!empty($pickup['name'])): ?>
+                                                    <br><small class="text-muted"><?= h($pickup['name']) ?></small>
+                                                <?php endif; ?>
+                                            </td>
                                             <td><?= h(app_format_datetime($pickup['start_datetime'])) ?></td>
                                             <td><?= h($summary ?: '—') ?></td>
                                             <td><?= layout_status_badge($pickup['status']) ?></td>

--- a/public/my_bookings.php
+++ b/public/my_bookings.php
@@ -228,7 +228,7 @@ if (!empty($_GET['deleted'])) {
                         <div class="card mb-3">
                             <div class="card-body">
                                 <h5 class="card-title">
-                                    Reservation #<?= $resId ?>
+                                    Reservation #<?= $resId ?><?= !empty($res['name']) ? ' — ' . h($res['name']) : '' ?>
                                 </h5>
                                 <p class="card-text">
                                     <strong>User Name:</strong>
@@ -332,7 +332,7 @@ if (!empty($_GET['deleted'])) {
                             <div class="card mb-3">
                                 <div class="card-body">
                                     <h5 class="card-title">
-                                        Reservation #<?= $resId ?>
+                                        Reservation #<?= $resId ?><?= !empty($res['name']) ? ' — ' . h($res['name']) : '' ?>
                                     </h5>
                                     <p class="card-text">
                                         <strong>User Name:</strong>

--- a/public/reservation_detail.php
+++ b/public/reservation_detail.php
@@ -96,6 +96,11 @@ $active  = 'staff_reservations.php'; // Treat detail view as part of booking his
             <div class="card-body">
                 <h5 class="card-title">Booking information</h5>
                 <p class="card-text">
+                    <?php if (!empty($reservation['name'])): ?>
+                        <strong>Name:</strong>
+                        <?= h($reservation['name']) ?><br>
+                    <?php endif; ?>
+
                     <strong>User Name:</strong>
                     <?= h($reservation['user_name'] ?? '(Unknown)') ?><br>
 

--- a/public/reservation_edit.php
+++ b/public/reservation_edit.php
@@ -445,15 +445,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $pdo->beginTransaction();
 
         try {
+            $editName = trim($_POST['reservation_name'] ?? '');
+            if ($editName === '') {
+                $editName = null;
+            }
+
             $updateRes = $pdo->prepare('
                 UPDATE reservations
                 SET start_datetime = :start,
-                    end_datetime = :end
+                    end_datetime = :end,
+                    name = :name
                 WHERE id = :id
             ');
             $updateRes->execute([
                 ':start' => $start,
                 ':end'   => $end,
+                ':name'  => $editName,
                 ':id'    => $id,
             ]);
 
@@ -606,6 +613,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <?php if ($from !== ''): ?>
                     <input type="hidden" name="from" value="<?= h($from) ?>">
                 <?php endif; ?>
+
+                <div class="mb-3">
+                    <label for="reservation-name" class="form-label fw-semibold">
+                        Reservation name <span class="text-muted fw-normal">(optional)</span>
+                    </label>
+                    <input type="text" class="form-control" id="reservation-name" name="reservation_name"
+                           placeholder="e.g. Studio A shoot" maxlength="255"
+                           value="<?= h($reservation['name'] ?? '') ?>">
+                </div>
 
                 <div class="row g-3 mb-3">
                     <div class="col-md-6">

--- a/public/staff_checkout.php
+++ b/public/staff_checkout.php
@@ -606,11 +606,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         INSERT INTO reservations (
                             user_name, user_email, user_id, snipeit_user_id,
                             asset_id, asset_name_cache,
-                            start_datetime, end_datetime, status
+                            start_datetime, end_datetime, status, name
                         ) VALUES (
                             :user_name, :user_email, :user_id, :snipeit_user_id,
                             0, :asset_name_cache,
-                            :start_datetime, :end_datetime, 'confirmed'
+                            :start_datetime, :end_datetime, 'confirmed', :name
                         )
                     ");
                     $insertRes->execute([
@@ -621,6 +621,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         ':asset_name_cache' => 'Pending checkout',
                         ':start_datetime'   => $selectedStart,
                         ':end_datetime'     => $selectedEnd,
+                        ':name'             => $selectedReservation['name'] ?? null,
                     ]);
                     $newReservationId = (int)$pdo->lastInsertId();
 
@@ -1419,7 +1420,7 @@ $active  = basename($_SERVER['PHP_SELF']);
                         $end     = display_datetime($res['end_datetime'] ?? '');
                                 ?>
                                 <option value="<?= $resId ?>" <?= $resId === $selectedReservationId ? 'selected' : '' ?>>
-                                    #<?= $resId ?> – <?= h($res['user_name'] ?? '') ?> (<?= h($start) ?> → <?= h($end) ?>): <?= h($summary) ?>
+                                    #<?= $resId ?><?= !empty($res['name']) ? ' — ' . h($res['name']) : '' ?> – <?= h($res['user_name'] ?? '') ?> (<?= h($start) ?> → <?= h($end) ?>): <?= h($summary) ?>
                                 </option>
                             <?php endforeach; ?>
                         </select>

--- a/public/staff_reservations.php
+++ b/public/staff_reservations.php
@@ -479,7 +479,12 @@ if (!empty($reservations)) {
                                 $itemsText = $modelsHtml . $assetsHtml;
                             ?>
                             <tr>
-                                <td data-label="ID">#<?= (int)$r['id'] ?></td>
+                                <td data-label="ID">
+                                    #<?= (int)$r['id'] ?>
+                                    <?php if (!empty($r['name'])): ?>
+                                        <br><small class="text-muted"><?= h($r['name']) ?></small>
+                                    <?php endif; ?>
+                                </td>
                                 <td data-label="User Name"><?= h($r['user_name'] ?? '(Unknown)') ?></td>
                                 <td data-label="Items Reserved" class="items-cell">
                                     <?= $itemsText !== '' ? '<div class="items-cell-content">' . $itemsText . '</div>' : '' ?>


### PR DESCRIPTION
## Summary
- Allow users to label reservations with a name (e.g. "Studio A shoot")
- Name is **required** for end users, **optional** for staff/admins
- Displayed on my_bookings, staff_reservations, reservation_detail, dashboard pending pickups, and staff_checkout reservation dropdown
- Name carries forward on rebook and is editable via reservation_edit
- No schema migration needed — `name` column already exists in `reservations` table (added in v1.1.0)

## Test plan
- [ ] Create a reservation as a non-staff user — verify name field is required and appears on my_bookings cards
- [ ] Try submitting without a name as non-staff — should be rejected
- [ ] Create a reservation as staff without a name — should succeed, no empty labels shown
- [ ] Verify name displays on staff_reservations table, reservation_detail info card, and dashboard pending pickups
- [ ] Edit a reservation — add/change/clear the name
- [ ] Rebook via staff_checkout — verify name carries to new reservation
- [ ] Check staff_checkout reservation dropdown includes name when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)