### PR TITLE
Fix availability not updating when selecting start datetime

### DIFF
--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -1950,7 +1950,7 @@ document.addEventListener('DOMContentLoaded', function () {
             hiddenInput: equipStartHidden,
             type: 'start',
             intervalMinutes: intervalMinutes,
-            onSelect: function (dt) { if (!equipEndManuallySet) autoSetEnd(equipEndPicker, dt); }
+            onSelect: function (dt) { if (!equipEndManuallySet) autoSetEnd(equipEndPicker, dt); if (equipEndHidden.value) submitWindowForm(equipForm); }
         }));
         if (equipStartHidden.value) equipStartPicker.setValue(equipStartHidden.value);
         if (equipEndHidden.value) { equipEndPicker.setValue(equipEndHidden.value); equipEndManuallySet = true; }
@@ -1975,7 +1975,7 @@ document.addEventListener('DOMContentLoaded', function () {
             hiddenInput: kitsStartHidden,
             type: 'start',
             intervalMinutes: intervalMinutes,
-            onSelect: function (dt) { if (!kitsEndManuallySet) autoSetEnd(kitsEndPicker, dt); }
+            onSelect: function (dt) { if (!kitsEndManuallySet) autoSetEnd(kitsEndPicker, dt); if (kitsEndHidden.value) submitWindowForm(kitsForm); }
         }));
         if (kitsStartHidden.value) kitsStartPicker.setValue(kitsStartHidden.value);
         if (kitsEndHidden.value) { kitsEndPicker.setValue(kitsEndHidden.value); kitsEndManuallySet = true; }


### PR DESCRIPTION
## Summary
- Start picker onSelect was only auto-setting the end time but never submitting the form to refresh availability
- Now submits the availability form whenever a start time is selected and an end time is already set
- Fixes both Equipment and Kits tab start pickers

## Test plan
- [ ] Select a start time when no end is set - should auto-set end and submit
- [ ] Change start time when end is already set - should submit and refresh availability
- [ ] Select end time - should still submit as before (no change)

Generated with [Claude Code](https://claude.com/claude-code)