### PR TITLE
Add hide-from-catalogue support via custom field

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -148,6 +148,7 @@ return [
         // Restrict which categories appear in the catalogue filter.
         // Leave empty to show all categories returned by Snipe-IT.
         'allowed_categories' => [],
+        'hide_field_name' => '',  // Snipe-IT custom field name; models with a truthy value are hidden from catalogue
     ],
 
     'checkout_limits' => [

--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -1017,6 +1017,12 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                 <?php foreach ($models as $model): ?>
                     <?php
                     $modelId    = (int)($model['id'] ?? 0);
+
+                    // Skip models hidden via custom field
+                    if (!empty($modelStats[$modelId]['hidden'])) {
+                        continue;
+                    }
+
                     $name       = $model['name'] ?? 'Model';
                     $manuName   = $model['manufacturer']['name'] ?? '';
                     $catName    = $model['category']['name'] ?? '';

--- a/public/settings.php
+++ b/public/settings.php
@@ -401,6 +401,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
     $catalogue['allowed_categories'] = $allowedCategories;
+    $catalogue['hide_field_name'] = trim($post('catalogue_hide_field_name', ''));
 
     $allStatuses = ['pending', 'confirmed', 'fulfilled', 'cancelled', 'missed'];
     $reservations = $config['reservations'] ?? [];
@@ -1012,6 +1013,11 @@ $allowedCategoryIds = array_map('intval', $allowedCategoryIds);
                                 <label class="form-label">API cache TTL (seconds)</label>
                                 <input type="number" name="app_api_cache_ttl" class="form-control" min="0" value="<?= (int)$cfg(['app', 'api_cache_ttl_seconds'], 60) ?>">
                                 <div class="form-text">Cache Snipe-IT GET responses. Set 0 to disable.</div>
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">Hide from catalogue field name</label>
+                                <input type="text" name="catalogue_hide_field_name" class="form-control" value="<?= h($cfg(['catalogue', 'hide_field_name'], '')) ?>">
+                                <div class="form-text">Snipe-IT custom field name. Models where any asset has this field set to a truthy value will be hidden from the catalogue but can still be scanned at checkout/checkin.</div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Adds a configurable Snipe-IT custom field name (e.g. "Hide from Catalogue") in Settings > Catalogue display
- Models where any asset has that field set to a truthy value (anything except empty, "No", "0", "false") are excluded from the catalogue
- Hidden models remain fully scannable at staff checkout, quick checkout, and quick checkin
- Empty/unset field name disables filtering (all models shown)

## Changes
- `config/config.example.php` — new `catalogue.hide_field_name` default
- `public/settings.php` — form input + POST handler
- `src/snipeit_client.php` — detect hide field in `prefetch_catalogue_model_stats()`
- `public/catalogue.php` — skip hidden models in equipment tab rendering

## Test plan
- [ ] Create a custom field "Hide from Catalogue" (checkbox or list) in Snipe-IT
- [ ] Set it to "Yes" on an asset of a model that currently appears in the catalogue
- [ ] Enter the field name in Settings > Catalogue display > "Hide from catalogue field name"
- [ ] Verify the model disappears from the catalogue
- [ ] Verify the asset can still be scanned at staff checkout and quick checkout/checkin
- [ ] Verify leaving the setting empty shows all models (no filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)