### PR TITLE
Fix Discord bot test button losing saved token

### DIFF
--- a/public/settings.php
+++ b/public/settings.php
@@ -491,13 +491,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $discordBot['dm_enabled'] = isset($_POST['discord_bot_dm_enabled']);
     $botTokenInput = $_POST['discord_bot_token'] ?? '';
     $botSecretInput = $_POST['discord_bot_oauth_client_secret'] ?? '';
-    if ($useRawSecrets) {
-        $discordBot['bot_token'] = $botTokenInput;
-        $discordBot['oauth_client_secret'] = $botSecretInput;
-    } else {
-        $discordBot['bot_token'] = $botTokenInput === '' ? ($loadedConfig['discord_bot']['bot_token'] ?? '') : $botTokenInput;
-        $discordBot['oauth_client_secret'] = $botSecretInput === '' ? ($loadedConfig['discord_bot']['oauth_client_secret'] ?? '') : $botSecretInput;
-    }
+    $discordBot['bot_token'] = $botTokenInput === '' ? ($loadedConfig['discord_bot']['bot_token'] ?? '') : $botTokenInput;
+    $discordBot['oauth_client_secret'] = $botSecretInput === '' ? ($loadedConfig['discord_bot']['oauth_client_secret'] ?? '') : $botSecretInput;
 
     $newConfig = $config;
     $newConfig['db_booking'] = $db;


### PR DESCRIPTION
## Summary
- Test Bot button sent an AJAX POST with empty password field
- The `useRawSecrets` flag (true for non-save actions) took the empty value literally instead of falling back to the saved config
- Result: "Discord bot token is empty" error when testing after a save+reload
- Fix: always use the keep-existing fallback for bot token and OAuth client secret

## Test plan
- [ ] Save Discord bot token in Settings
- [ ] Reload page, click Test Bot -- should succeed
- [ ] Click Test Bot without saving first -- should still read from saved config