### PR TITLE
Allow admins to bypass checkout renewal duration limits

### DIFF
--- a/public/checked_out_assets.php
+++ b/public/checked_out_assets.php
@@ -252,7 +252,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $renewUserId = (int)($assetInfo['assigned_to_id'] ?? 0);
                 $renewModelId = (int)($assetInfo['model_id'] ?? 0);
 
-                if ($clCfg['enabled'] && $renewUserId > 0) {
+                if ($clCfg['enabled'] && $renewUserId > 0 && !$isAdmin) {
                     $newExpectedDt = new DateTime($normalized, app_get_timezone());
                     $renewErr = validate_renewal_duration(
                         $renewUserId,
@@ -369,7 +369,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $bulkAssetMap[(int)$bar['asset_id']] = $bar;
             }
 
-            if ($clCfg['enabled']) {
+            if ($clCfg['enabled'] && !$isAdmin) {
                 foreach ($bulkAssetIds as $aid) {
                     $info = $bulkAssetMap[$aid] ?? null;
                     if ($info === null) {


### PR DESCRIPTION
## Summary
- Admins can now extend checkouts past configured max checkout/renewal/total hour limits
- Staff still have duration limits enforced
- Applies to both single asset renewal and bulk renewal

## Test plan
- [ ] As admin, renew a checkout past the max hours -- verify it succeeds
- [ ] As staff (non-admin), attempt the same -- verify it is blocked