### PR TITLE
Add admin-only /list-requests command to Discord bot

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -4,6 +4,8 @@ CLIENT_ID=
 FACULTY_SERVER_ID=
 # Comma-separated guild IDs where the bot should register commands
 GUILD_IDS=
+# Discord user ID allowed to run /list-requests
+ADMIN_USER_ID=
 
 # MySQL (same as SnipeScheduler)
 DB_HOST=localhost

--- a/bot/src/commands/list-requests.js
+++ b/bot/src/commands/list-requests.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const pool = require('../db');
+
+const ADMIN_USER_ID = process.env.ADMIN_USER_ID || '';
+
+const STATUS_EMOJI = {
+  open: '\uD83D\uDD35',       // 🔵
+  approved: '\u2705',         // ✅
+  held: '\u23F8\uFE0F',       // ⏸️
+};
+
+function statusLabel(status) {
+  const emoji = STATUS_EMOJI[status] ?? '•';
+  const label = status.charAt(0).toUpperCase() + status.slice(1);
+  return `${emoji} ${label}`;
+}
+
+const data = new SlashCommandBuilder()
+  .setName('list-requests')
+  .setDescription('List all active purchase requests (admin only)');
+
+async function execute(interaction) {
+  // Gate to admin user only
+  if (interaction.user.id !== ADMIN_USER_ID) {
+    await interaction.reply({
+      content: 'This command is restricted.',
+      flags: 64, // ephemeral
+    });
+    return;
+  }
+
+  await interaction.deferReply(); // public reply
+
+  let rows;
+  try {
+    [rows] = await pool.execute(
+      `SELECT id, item_name, submitter_name, department, quantity,
+              status, importance, estimated_cost, is_faculty, created_at
+       FROM purchase_requests
+       WHERE status IN ('open', 'approved', 'held')
+       ORDER BY
+         FIELD(status, 'open', 'approved', 'held'),
+         FIELD(importance, 'critical', 'high', 'medium', 'low'),
+         created_at ASC
+       LIMIT 25`
+    );
+  } catch (err) {
+    console.error('DB error fetching requests:', err);
+    await interaction.editReply({ content: 'Database error fetching requests.' });
+    return;
+  }
+
+  if (rows.length === 0) {
+    await interaction.editReply({ content: 'No active purchase requests.' });
+    return;
+  }
+
+  // Build a table-style message using a code block for alignment
+  const lines = [];
+  lines.push('```');
+  lines.push(
+    padRight('#', 4) +
+    padRight('Status', 10) +
+    padRight('Item', 28) +
+    padRight('Dept', 16) +
+    padRight('Qty', 5) +
+    padRight('Cost', 10) +
+    'Submitter'
+  );
+  lines.push('-'.repeat(90));
+
+  for (const row of rows) {
+    const cost = row.estimated_cost !== null
+      ? '$' + Number(row.estimated_cost).toFixed(2)
+      : '—';
+    const faculty = row.is_faculty ? ' [F]' : '';
+
+    lines.push(
+      padRight(String(row.id), 4) +
+      padRight(row.status, 10) +
+      padRight(truncate(row.item_name, 26), 28) +
+      padRight(truncate(row.department, 14), 16) +
+      padRight(String(row.quantity), 5) +
+      padRight(cost, 10) +
+      truncate(row.submitter_name, 20) + faculty
+    );
+  }
+
+  lines.push('```');
+
+  const totalCost = rows.reduce((sum, r) => {
+    return sum + (r.estimated_cost !== null ? Number(r.estimated_cost) * r.quantity : 0);
+  }, 0);
+
+  const summary = `**${rows.length}** active request${rows.length !== 1 ? 's' : ''}`;
+  const costSummary = totalCost > 0
+    ? ` · Est. total: **$${totalCost.toFixed(2)}**`
+    : '';
+
+  await interaction.editReply({
+    content: summary + costSummary + '\n' + lines.join('\n'),
+  });
+}
+
+function padRight(str, len) {
+  if (str.length >= len) return str.slice(0, len);
+  return str + ' '.repeat(len - str.length);
+}
+
+function truncate(str, max) {
+  if (str.length <= max) return str;
+  return str.slice(0, max - 1) + '…';
+}
+
+module.exports = { data, execute };

--- a/bot/src/commands/list-requests.js
+++ b/bot/src/commands/list-requests.js
@@ -67,13 +67,17 @@ async function execute(interaction) {
     padRight('Dept', 16) +
     padRight('Qty', 5) +
     padRight('Cost', 10) +
+    padRight('Ext', 12) +
     'Submitter'
   );
-  lines.push('-'.repeat(90));
+  lines.push('-'.repeat(102));
 
   for (const row of rows) {
     const cost = row.estimated_cost !== null
       ? '$' + Number(row.estimated_cost).toFixed(2)
+      : '—';
+    const ext = row.estimated_cost !== null
+      ? '$' + (Number(row.estimated_cost) * row.quantity).toFixed(2)
       : '—';
     const faculty = row.is_faculty ? ' [F]' : '';
 
@@ -84,6 +88,7 @@ async function execute(interaction) {
       padRight(truncate(row.department, 14), 16) +
       padRight(String(row.quantity), 5) +
       padRight(cost, 10) +
+      padRight(ext, 12) +
       truncate(row.submitter_name, 20) + faculty
     );
   }

--- a/bot/src/deploy-commands.js
+++ b/bot/src/deploy-commands.js
@@ -5,10 +5,12 @@ const { REST, Routes } = require('discord.js');
 
 const purchaseRequest = require('./commands/purchase-request');
 const myRequests = require('./commands/my-requests');
+const listRequests = require('./commands/list-requests');
 
 const commands = [
   purchaseRequest.data.toJSON(),
   myRequests.data.toJSON(),
+  listRequests.data.toJSON(),
 ];
 
 const rest = new REST({ version: '10' }).setToken(process.env.BOT_TOKEN);

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -5,6 +5,7 @@ const { Client, GatewayIntentBits, Collection } = require('discord.js');
 
 const purchaseRequest = require('./commands/purchase-request');
 const myRequests = require('./commands/my-requests');
+const listRequests = require('./commands/list-requests');
 
 const client = new Client({
   intents: [
@@ -17,6 +18,7 @@ const client = new Client({
 client.commands = new Collection();
 client.commands.set(purchaseRequest.data.name, purchaseRequest);
 client.commands.set(myRequests.data.name, myRequests);
+client.commands.set(listRequests.data.name, listRequests);
 
 client.once('ready', () => {
   console.log(`Logged in as ${client.user.tag}`);


### PR DESCRIPTION
## Summary
- New `/list-requests` slash command prints a table of active purchase requests to the channel
- Restricted to `ADMIN_USER_ID` configured in `.env`
- Shows ID, status, item, dept, qty, unit cost, extended cost (cost × qty), and submitter
- Sorted by status then importance, limited to 25 rows
- Displays running total of estimated costs

## Test plan
- [ ] Add `ADMIN_USER_ID` to `.env`, re-deploy commands, restart bot
- [ ] Run `/list-requests` as admin — verify table output
- [ ] Run `/list-requests` as non-admin — verify "This command is restricted" ephemeral reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)