### PR TITLE
Restrict reservation deletion to admins and improve confirmation

### DIFF
--- a/public/delete_reservation.php
+++ b/public/delete_reservation.php
@@ -45,9 +45,9 @@ $ownsReservation = $currentSnipeId !== ''
     && isset($reservation['snipeit_user_id'])
     && (string)$reservation['snipeit_user_id'] === $currentSnipeId;
 
-if (!$isStaff && !$ownsReservation) {
+if (!$isAdmin && !$ownsReservation) {
     http_response_code(403);
-    echo 'Access denied.';
+    echo 'Only admins or the reservation owner can delete reservations.';
     exit;
 }
 

--- a/public/my_bookings.php
+++ b/public/my_bookings.php
@@ -372,7 +372,7 @@ foreach ($kitNames as $kid => $kname) {
                                     ?>
                                     <form method="post"
                                           action="delete_reservation.php"
-                                          onsubmit="return confirm('Delete this reservation and all its items? This cannot be undone.');">
+                                          onsubmit="return confirm('Delete reservation #<?= $resId ?>?\n\nThis will permanently remove the reservation and all its items. This cannot be undone.');">
                                         <input type="hidden" name="reservation_id" value="<?= $resId ?>">
                                         <button type="submit" class="btn btn-outline-danger btn-sm">
                                             Delete reservation
@@ -485,7 +485,7 @@ foreach ($kitNames as $kid => $kname) {
                                         ?>
                                         <form method="post"
                                               action="delete_reservation.php"
-                                              onsubmit="return confirm('Delete this reservation and all its items? This cannot be undone.');">
+                                              onsubmit="return confirm('Delete reservation #<?= $resId ?>?\n\nThis will permanently remove the reservation and all its items. This cannot be undone.');">
                                             <input type="hidden" name="reservation_id" value="<?= $resId ?>">
                                             <button type="submit" class="btn btn-outline-danger btn-sm">
                                                 Delete reservation

--- a/public/reservation_detail.php
+++ b/public/reservation_detail.php
@@ -263,11 +263,11 @@ $active  = 'staff_reservations.php'; // Treat detail view as part of booking his
 
             <?php
                 $deletableStatuses = (load_config())['reservations']['deletable_statuses'] ?? ['pending', 'confirmed', 'cancelled', 'missed'];
-                if (in_array($reservation['status'] ?? '', $deletableStatuses, true)):
+                if ($isAdmin && in_array($reservation['status'] ?? '', $deletableStatuses, true)):
             ?>
             <form method="post"
                   action="delete_reservation.php"
-                  onsubmit="return confirm('Delete this booking and all its items? This cannot be undone.');">
+                  onsubmit="return confirm('Delete reservation #<?= (int)$id ?> for <?= h($reservation['user_name'] ?? 'unknown') ?>?\n\nThis will permanently remove the reservation and all its items. This cannot be undone.');">
                 <input type="hidden" name="reservation_id" value="<?= (int)$id ?>">
                 <button class="btn btn-outline-danger" type="submit">
                     Delete this booking

--- a/public/staff_checkout.php
+++ b/public/staff_checkout.php
@@ -597,6 +597,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $willDeleteReservation = $totalQtyBefore <= 1;
                 }
 
+                if ($willDeleteReservation && !$isAdmin) {
+                    throw new RuntimeException('Only admins can delete reservations. You can cancel it instead.');
+                }
                 if ($willDeleteReservation && ($_POST['confirm_delete'] ?? '') !== '1') {
                     throw new RuntimeException('Confirmation required to delete the reservation.');
                 }

--- a/public/staff_reservations.php
+++ b/public/staff_reservations.php
@@ -557,11 +557,11 @@ if (!empty($reservations)) {
                                         <?php endif; ?>
                                         <?php
                                             $deletableStatuses = (load_config())['reservations']['deletable_statuses'] ?? ['pending', 'confirmed', 'cancelled', 'missed'];
-                                            if (in_array($status, $deletableStatuses, true)):
+                                            if ($isAdmin && in_array($status, $deletableStatuses, true)):
                                         ?>
                                         <form method="post"
                                               action="delete_reservation.php"
-                                              onsubmit="return confirm('Delete this reservation and all its items? This cannot be undone.');">
+                                              onsubmit="return confirm('Delete reservation #<?= (int)$r['id'] ?> for <?= h($r['user_name'] ?? 'unknown') ?>?\n\nThis will permanently remove the reservation and all its items. This cannot be undone.');">
                                             <input type="hidden"
                                                    name="reservation_id"
                                                    value="<?= (int)$r['id'] ?>">


### PR DESCRIPTION
## Summary
- **Delete buttons hidden** for non-admin staff on: Reservation History, Reservation Detail, and Staff Checkout (remove last item)
- **Server-side enforcement**: `delete_reservation.php` now returns 403 for non-admin, non-owner requests; staff_checkout remove-last-item path blocked for non-admins
- **Users can still delete their own** reservations from My Bookings
- **Confirmation dialogs improved**: now include reservation ID and user name (e.g. "Delete reservation #299 for Anastasiia Shtanko?") so the operator knows exactly what they're deleting

## Test plan
- [ ] Log in as staff (non-admin) -- verify no Delete buttons on Reservation History
- [ ] Log in as admin -- verify Delete buttons visible with improved confirmation text
- [ ] As staff, try to POST directly to delete_reservation.php -- verify 403
- [ ] As regular user, delete own reservation from My Bookings -- verify it works with reservation ID in confirmation
- [ ] Staff removes last item from a reservation on checkout page -- verify blocked with error message