### PR TITLE
QR /v/{asset_tag} docs page + scanner URL handling

### DIFF
--- a/docs/qr-docs.md
+++ b/docs/qr-docs.md
@@ -1,0 +1,85 @@
+# QR codes and the `/v/{asset_tag}` documentation page
+
+## What this is
+
+Physical asset labels carry a dual-purpose QR code:
+
+    https://wrapit.us/v/{asset_tag}
+
+Two flows use the same code:
+
+1. **USB barcode scanner** types the full URL into a scan field on
+   `quick_checkin.php`, `quick_checkout.php`, or `staff_checkout.php`. JS
+   (`stripWrapitUrl` in `public/assets/nav.js`) peels the URL down to the
+   bare asset_tag before processing; `normalize_scanned_tag()` in
+   `src/snipeit_client.php` does the same server-side as a safety net.
+2. **Phone camera** opens the URL in a browser. `public/v.php` renders a
+   public documentation page for the asset's parent model, listing files
+   attached to that model in Snipe-IT.
+
+## Documentation page behavior
+
+`v.php` resolves asset_tag → asset → model via the Snipe-IT API, then:
+
+- Lists each file attached to the model (icon + filename, links to
+  `v_file.php` which proxies the download).
+- Scans every `.txt` file for embedded http(s) URLs.
+  - For a file named exactly **`links.txt`**: the .txt itself is hidden;
+    each URL becomes its own entry in the list.
+  - For other `.txt` files: the download stays, and extracted URLs are
+    rendered as additional entries underneath.
+- YouTube URLs (watch / shorts / embed / live / `youtu.be`) get
+  thumbnail + title via YouTube oEmbed. Capped at 10 lookups per page
+  render. oEmbed results (including failures) are cached for 7 days.
+
+No login required for `v.php` or `v_file.php` — the QR is on the physical
+asset, so anyone with physical access (or who already knows the tag) can
+read docs.
+
+## Deploy: nginx redirect on `wrapit.us`
+
+`wrapit.us` is a separate vhost from `ss.studio6h.com` (the SnipeScheduler
+app) and does not have PHP-FPM configured. Add a 302 to its server block
+so `/v/{tag}` reaches the app:
+
+    # /etc/nginx/sites-enabled/wrapit.us.conf
+    server {
+        server_name wrapit.us;
+        # ... existing config ...
+
+        # Per-asset documentation page (served by SnipeScheduler).
+        # Match the asset-tag pattern: 4 digit number, or 'svad'+5 digits.
+        location ~* ^/v/([A-Za-z0-9._-]+)/?$ {
+            return 302 https://ss.studio6h.com/v.php?tag=$1;
+        }
+    }
+
+Reload after editing:
+
+    sudo nginx -t && sudo systemctl reload nginx
+
+## Testing checklist
+
+- [ ] Scan a printed QR with a USB barcode scanner into the `quick_checkin`
+      scan field. The flash message should show the bare asset_tag, not the
+      URL.
+- [ ] Same scan in `quick_checkout` and `staff_checkout`.
+- [ ] Browse `https://wrapit.us/v/{a-real-tag}` on a phone. Should 302 to
+      `ss.studio6h.com/v.php?tag={tag}` and render the model name + file
+      list.
+- [ ] Attach a `links.txt` to a model in Snipe-IT with one URL per line
+      including a YouTube link. Reload the v.php page — the .txt should not
+      appear as a download; each URL should be its own entry; the YouTube
+      entry should have thumbnail + title.
+- [ ] Attach `setup-notes.txt` containing prose with a URL embedded. Both
+      the .txt download and the extracted URL should appear.
+
+## Caches
+
+- Model files (`get_model_files`): 1h TTL.
+- `.txt` URL extractions (`scan_txt_for_urls`): 1h TTL.
+- YouTube oEmbed lookups (`youtube_oembed`): 7d TTL (success and failure
+  both cached).
+
+All cached under `config/cache/`. Safe to delete if a model's docs change
+and you don't want to wait for the TTL.

--- a/public/assets/nav.js
+++ b/public/assets/nav.js
@@ -1018,4 +1018,14 @@
         });
     });
 
+    // QR-code dual-purpose URL strip.
+    // Physical asset labels carry "https://wrapit.us/v/{tag}" which works both
+    // as a phone-camera link and as scanner input. When a USB scanner submits
+    // the full URL into a scan field, peel it back to the bare asset_tag.
+    window.stripWrapitUrl = function (value) {
+        var s = String(value == null ? '' : value).trim();
+        var m = s.match(/^https?:\/\/(?:www\.)?wrapit\.us\/v\/([^\/\s?#]+)\/?$/i);
+        return m ? decodeURIComponent(m[1]) : s;
+    };
+
 })();

--- a/public/quick_checkin.php
+++ b/public/quick_checkin.php
@@ -123,7 +123,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $mode = $_POST['mode'] ?? '';
 
     if ($mode === 'add_asset' || $mode === 'add_asset_by_id') {
-        $tag     = trim($_POST['asset_tag'] ?? '');
+        $tag     = normalize_scanned_tag($_POST['asset_tag'] ?? '');
         $assetIdInput = (int)($_POST['asset_id'] ?? 0);
 
         if ($mode === 'add_asset_by_id' && $assetIdInput <= 0) {
@@ -1056,7 +1056,7 @@ layout_page_start([
     // Intercept form submit
     scanForm.addEventListener('submit', function(e) {
         e.preventDefault();
-        enqueueTag(scanInput.value.trim());
+        enqueueTag(stripWrapitUrl(scanInput.value));
     });
 
     function enqueueTag(tag) {

--- a/public/quick_checkout.php
+++ b/public/quick_checkout.php
@@ -136,7 +136,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $mode = $_POST['mode'] ?? '';
 
     if ($mode === 'add_asset') {
-        $tag = trim($_POST['asset_tag'] ?? '');
+        $tag = normalize_scanned_tag($_POST['asset_tag'] ?? '');
         if ($tag === '') {
             $errors[] = 'Please scan or enter an asset tag.';
         } else {

--- a/public/staff_checkout.php
+++ b/public/staff_checkout.php
@@ -815,7 +815,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
     } elseif ($mode === 'scan_asset') {
-        $tag = trim($_POST['scan_tag'] ?? '');
+        $tag = normalize_scanned_tag($_POST['scan_tag'] ?? '');
         $resId = $selectedReservationId;
 
         if (!$selectedReservation) {
@@ -1009,7 +1009,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         header('Location: ' . $selfUrl);
         exit;
     } elseif ($mode === 'add_asset') {
-        $tag = trim($_POST['asset_tag'] ?? '');
+        $tag = normalize_scanned_tag($_POST['asset_tag'] ?? '');
         if (!$selectedReservation) {
             $checkoutErrors[] = 'Please select a reservation for today before adding assets.';
         } elseif ($tag === '') {
@@ -3040,7 +3040,7 @@ layout_page_start([
     // Intercept form submit
     scanForm.addEventListener('submit', function(e) {
         e.preventDefault();
-        enqueueTag(scanInput.value.trim());
+        enqueueTag(stripWrapitUrl(scanInput.value));
     });
 
     function enqueueTag(tag) {

--- a/public/v.php
+++ b/public/v.php
@@ -1,0 +1,226 @@
+<?php
+// Public per-asset documentation page.
+//
+// Reached via:   https://wrapit.us/v/{asset_tag}   (nginx 302 → here)
+//      or:      /v.php?tag={asset_tag}            (direct)
+//
+// Resolves the asset_tag → asset → parent model, then renders the file list
+// attached to that model in Snipe-IT. .txt files are scanned for embedded
+// URLs and rendered inline (links.txt fully inlined; other .txt rendered as
+// download + extracted URLs). YouTube URLs get thumbnail + title via oEmbed.
+//
+// No login required. The proxy backing file downloads (v_file.php) is also
+// public — anyone with the QR can read docs, matching the physical access
+// model.
+
+require_once __DIR__ . '/../src/bootstrap.php';
+require_once SRC_PATH . '/snipeit_client.php';
+require_once SRC_PATH . '/qr_docs.php';
+
+if (!function_exists('h')) {
+    function h(?string $value): string
+    {
+        return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+$rawTag = $_GET['tag'] ?? '';
+$tag    = normalize_scanned_tag($rawTag);
+
+$valid = $tag !== '' && (bool)preg_match('/^[A-Za-z0-9._-]+$/', $tag);
+
+$asset      = null;
+$modelId    = 0;
+$modelName  = '';
+$files      = [];
+$lookupErr  = '';
+
+if (!$valid) {
+    $lookupErr = 'Invalid asset tag.';
+    http_response_code(400);
+} else {
+    try {
+        $asset      = find_asset_by_tag($tag);
+        $modelId    = (int)($asset['model']['id'] ?? 0);
+        $modelName  = (string)($asset['model']['name'] ?? '');
+        if ($modelId <= 0) {
+            throw new Exception('Asset has no model.');
+        }
+        $files = get_model_files($modelId);
+    } catch (Throwable $e) {
+        $lookupErr = $e->getMessage();
+        http_response_code(404);
+    }
+}
+
+/**
+ * Bootstrap icon class for a file extension.
+ */
+function v_icon_for_ext(string $ext): string
+{
+    $ext = strtolower($ext);
+    $map = [
+        'pdf'  => 'bi-file-earmark-pdf',
+        'doc'  => 'bi-file-earmark-word',  'docx' => 'bi-file-earmark-word',
+        'xls'  => 'bi-file-earmark-excel', 'xlsx' => 'bi-file-earmark-excel', 'ods' => 'bi-file-earmark-excel',
+        'odt'  => 'bi-file-earmark-word',  'odp'  => 'bi-file-earmark-slides',
+        'png'  => 'bi-file-earmark-image', 'jpg'  => 'bi-file-earmark-image', 'jpeg' => 'bi-file-earmark-image',
+        'gif'  => 'bi-file-earmark-image', 'webp' => 'bi-file-earmark-image', 'avif' => 'bi-file-earmark-image',
+        'svg'  => 'bi-file-earmark-image', 'ico'  => 'bi-file-earmark-image', 'jfif' => 'bi-file-earmark-image',
+        'mp4'  => 'bi-file-earmark-play',  'mov'  => 'bi-file-earmark-play',  'webm' => 'bi-file-earmark-play',
+        'mp3'  => 'bi-file-earmark-music', 'wav'  => 'bi-file-earmark-music', 'ogg'  => 'bi-file-earmark-music',
+        'zip'  => 'bi-file-earmark-zip',   'rar'  => 'bi-file-earmark-zip',
+        'txt'  => 'bi-file-earmark-text',  'rtf'  => 'bi-file-earmark-text',
+        'json' => 'bi-file-earmark-code',  'xml'  => 'bi-file-earmark-code',
+    ];
+    return $map[$ext] ?? 'bi-file-earmark';
+}
+
+// Build the list of rendered entries:
+//  - kind = 'file'    → a Snipe-IT file download
+//  - kind = 'link'    → a plain URL extracted from a .txt
+//  - kind = 'youtube' → a YouTube URL with oEmbed metadata
+$entries = [];
+
+// Throttle oEmbed lookups so a giant links.txt can't hammer YouTube.
+$youtubeBudget = 10;
+
+foreach ($files as $f) {
+    if (!is_array($f)) continue;
+    $fid       = (int)($f['id'] ?? 0);
+    $fnameRaw  = (string)($f['filename'] ?? $f['name'] ?? '');
+    if ($fid <= 0 || $fnameRaw === '') continue;
+    $ext       = strtolower(pathinfo($fnameRaw, PATHINFO_EXTENSION));
+    $isTxt     = $ext === 'txt';
+    $isLinksTxt = $isTxt && strcasecmp($fnameRaw, 'links.txt') === 0;
+
+    $downloadHref = 'v_file.php?model_id=' . $modelId . '&file_id=' . $fid;
+
+    $extractedUrls = [];
+    if ($isTxt) {
+        $extractedUrls = scan_txt_for_urls($modelId, $fid);
+    }
+
+    if (!$isLinksTxt) {
+        $entries[] = [
+            'kind'  => 'file',
+            'label' => $fnameRaw,
+            'ext'   => $ext,
+            'href'  => $downloadHref,
+            'notes' => (string)($f['notes'] ?? ''),
+        ];
+    }
+
+    foreach ($extractedUrls as $url) {
+        if (is_youtube_url($url) && $youtubeBudget > 0) {
+            $youtubeBudget--;
+            $meta = youtube_oembed($url);
+            $entries[] = [
+                'kind'      => 'youtube',
+                'href'      => $url,
+                'title'     => $meta['title'] ?? $url,
+                'thumbnail' => $meta['thumbnail_url'] ?? '',
+                'channel'   => $meta['author_name'] ?? '',
+            ];
+        } else {
+            $entries[] = [
+                'kind'  => 'link',
+                'href'  => $url,
+                'label' => $url,
+            ];
+        }
+    }
+}
+
+$pageTitle = $modelName !== '' ? ($modelName . ' — Documentation') : 'Asset Documentation';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?= h($pageTitle) ?></title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<link rel="stylesheet" href="assets/style.css">
+<style>
+  body { background: var(--surface-page, #f6f7fb); }
+  .v-shell { max-width: 760px; margin: 2rem auto; padding: 0 1rem 4rem; }
+  .v-header { margin-bottom: 1.5rem; }
+  .v-header h1 { font-size: 1.5rem; margin: 0 0 .25rem; }
+  .v-header .tag { font-family: ui-monospace, monospace; color: var(--text-muted, #6c757d); }
+  .v-empty { padding: 2rem; text-align: center; color: var(--text-muted, #6c757d); border: 1px dashed var(--border-color, #dee2e6); border-radius: 8px; }
+  .v-entry { display: flex; gap: .75rem; align-items: center; padding: .75rem; border: 1px solid var(--border-color, #dee2e6); border-radius: 8px; margin-bottom: .5rem; background: #fff; text-decoration: none; color: inherit; }
+  .v-entry:hover { background: #f9fafc; border-color: #adb5bd; }
+  .v-entry .icon { font-size: 1.5rem; color: var(--text-muted, #6c757d); flex: 0 0 auto; }
+  .v-entry .label { flex: 1 1 auto; min-width: 0; word-break: break-word; }
+  .v-entry .sub { display: block; font-size: .8125rem; color: var(--text-muted, #6c757d); margin-top: .125rem; }
+  .v-entry img.thumb { width: 96px; height: 54px; object-fit: cover; border-radius: 4px; flex: 0 0 auto; }
+  .v-footer { margin-top: 2rem; text-align: center; font-size: .8125rem; color: var(--text-muted, #6c757d); }
+</style>
+</head>
+<body>
+<div class="v-shell">
+
+  <?php if ($lookupErr !== ''): ?>
+    <div class="v-header">
+      <h1>Asset not found</h1>
+      <div class="tag"><?= h($tag !== '' ? $tag : $rawTag) ?></div>
+    </div>
+    <div class="v-empty">
+      <p class="mb-1"><?= h($lookupErr) ?></p>
+      <p class="mb-0 small">If this tag is correct, check that the asset still exists in Snipe-IT.</p>
+    </div>
+  <?php else: ?>
+    <div class="v-header">
+      <h1><?= h($modelName !== '' ? $modelName : 'Asset') ?></h1>
+      <div class="tag">Asset tag: <?= h($tag) ?></div>
+    </div>
+
+    <?php if (empty($entries)): ?>
+      <div class="v-empty">
+        <p class="mb-1">No documentation uploaded for this model yet.</p>
+        <p class="mb-0 small">Attach files to the model in Snipe-IT and they'll show here.</p>
+      </div>
+    <?php else: ?>
+      <?php foreach ($entries as $e): ?>
+        <?php if ($e['kind'] === 'youtube'): ?>
+          <a class="v-entry" href="<?= h($e['href']) ?>" target="_blank" rel="noopener">
+            <?php if (!empty($e['thumbnail'])): ?>
+              <img class="thumb" src="<?= h($e['thumbnail']) ?>" alt="" loading="lazy">
+            <?php else: ?>
+              <i class="icon bi bi-youtube" style="color:#c00;"></i>
+            <?php endif; ?>
+            <span class="label">
+              <?= h($e['title']) ?>
+              <?php if (!empty($e['channel'])): ?>
+                <span class="sub">YouTube · <?= h($e['channel']) ?></span>
+              <?php else: ?>
+                <span class="sub">YouTube</span>
+              <?php endif; ?>
+            </span>
+          </a>
+        <?php elseif ($e['kind'] === 'link'): ?>
+          <a class="v-entry" href="<?= h($e['href']) ?>" target="_blank" rel="noopener">
+            <i class="icon bi bi-link-45deg"></i>
+            <span class="label"><?= h($e['label']) ?></span>
+          </a>
+        <?php else: /* file */ ?>
+          <a class="v-entry" href="<?= h($e['href']) ?>" target="_blank" rel="noopener">
+            <i class="icon bi <?= h(v_icon_for_ext($e['ext'])) ?>"></i>
+            <span class="label">
+              <?= h($e['label']) ?>
+              <?php if (!empty($e['notes'])): ?>
+                <span class="sub"><?= h($e['notes']) ?></span>
+              <?php endif; ?>
+            </span>
+          </a>
+        <?php endif; ?>
+      <?php endforeach; ?>
+    <?php endif; ?>
+  <?php endif; ?>
+
+  <div class="v-footer">WrapIt</div>
+</div>
+</body>
+</html>

--- a/public/v_file.php
+++ b/public/v_file.php
@@ -1,0 +1,65 @@
+<?php
+// Public file proxy for the per-model documentation page (v.php).
+//
+// Streams a Snipe-IT model file back to the browser, authenticated against
+// the configured Snipe-IT API token (the end user is not authenticated).
+//
+// Access control: file_id must actually belong to model_id. Same threat
+// model as v.php — anyone with a valid QR/tag can already reach this; we
+// only block accidental cross-model access via the proxy.
+
+require_once __DIR__ . '/../src/bootstrap.php';
+require_once SRC_PATH . '/snipeit_client.php';
+
+$modelId = (int)($_GET['model_id'] ?? 0);
+$fileId  = (int)($_GET['file_id'] ?? 0);
+
+if ($modelId <= 0 || $fileId <= 0) {
+    http_response_code(400);
+    echo 'Invalid request.';
+    exit;
+}
+
+// Verify the file is actually attached to this model. Avoids using the
+// proxy as a general-purpose "any file by id" reader.
+try {
+    $files = get_model_files($modelId);
+} catch (Throwable $e) {
+    http_response_code(502);
+    echo 'Unable to verify file ownership.';
+    exit;
+}
+
+$found = null;
+foreach ($files as $f) {
+    if (is_array($f) && (int)($f['id'] ?? 0) === $fileId) {
+        $found = $f;
+        break;
+    }
+}
+if ($found === null) {
+    http_response_code(404);
+    echo 'File not found for this model.';
+    exit;
+}
+
+try {
+    [$contentType, $contentDisposition, $body] = fetch_model_file($modelId, $fileId);
+} catch (Throwable $e) {
+    http_response_code(502);
+    echo 'Upstream fetch failed.';
+    exit;
+}
+
+header('Content-Type: ' . $contentType);
+if ($contentDisposition !== '') {
+    header('Content-Disposition: ' . $contentDisposition);
+} else {
+    $fname = (string)($found['filename'] ?? $found['name'] ?? 'download');
+    $safe  = preg_replace('/[^\w.\-]+/', '_', $fname);
+    header('Content-Disposition: inline; filename="' . $safe . '"');
+}
+header('Content-Length: ' . strlen($body));
+header('Cache-Control: private, max-age=300');
+
+echo $body;

--- a/src/qr_docs.php
+++ b/src/qr_docs.php
@@ -1,0 +1,108 @@
+<?php
+// Helpers backing public/v.php (per-model QR documentation page).
+//
+// - extract_urls_from_text(): pull http(s) URLs out of a text blob
+// - is_youtube_url():        recognize YouTube watch/shorts/embed/youtu.be URLs
+// - youtube_oembed():        fetch title + thumbnail via YouTube's oEmbed API,
+//                            with 7-day caching to avoid hammering the endpoint
+// - scan_txt_for_urls():     read a Snipe-IT model .txt file and return its URLs,
+//                            cached so repeat page renders don't re-fetch
+
+require_once __DIR__ . '/snipeit_client.php';
+
+if (!function_exists('extract_urls_from_text')) {
+    function extract_urls_from_text(string $text): array
+    {
+        // Match http(s) URLs, stop at whitespace and common closing punctuation.
+        // Trailing punctuation likely to be sentence-end is trimmed.
+        if (!preg_match_all('#https?://[^\s\)\]\>\"\'<]+#i', $text, $m)) {
+            return [];
+        }
+        $urls = [];
+        foreach ($m[0] as $u) {
+            $u = rtrim($u, ".,;:!?");
+            if ($u !== '' && !in_array($u, $urls, true)) {
+                $urls[] = $u;
+            }
+        }
+        return $urls;
+    }
+}
+
+if (!function_exists('is_youtube_url')) {
+    function is_youtube_url(string $url): bool
+    {
+        return (bool)preg_match(
+            '#^https?://(?:www\.|m\.)?(?:youtube\.com/(?:watch\?|shorts/|embed/|live/)|youtu\.be/)#i',
+            $url
+        );
+    }
+}
+
+if (!function_exists('youtube_oembed')) {
+    /**
+     * Fetch YouTube oEmbed metadata for a URL. Returns null on any failure.
+     * Successful results AND failures both cache for 7 days so a broken or
+     * private video doesn't get retried on every page view.
+     */
+    function youtube_oembed(string $url): ?array
+    {
+        $cacheKey = 'oembed_yt_' . md5($url);
+        $cached = snipeit_cache_get($cacheKey, 86400 * 7);
+        if ($cached !== null) {
+            return empty($cached['ok']) ? null : $cached['data'];
+        }
+
+        $api = 'https://www.youtube.com/oembed?format=json&url=' . urlencode($url);
+        $ch  = curl_init($api);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept: application/json']);
+        $body = curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($code !== 200 || !is_string($body)) {
+            snipeit_cache_set($cacheKey, ['ok' => false]);
+            return null;
+        }
+        $data = json_decode($body, true);
+        if (!is_array($data)) {
+            snipeit_cache_set($cacheKey, ['ok' => false]);
+            return null;
+        }
+
+        $out = [
+            'title'         => isset($data['title']) ? (string)$data['title'] : '',
+            'thumbnail_url' => isset($data['thumbnail_url']) ? (string)$data['thumbnail_url'] : '',
+            'author_name'   => isset($data['author_name']) ? (string)$data['author_name'] : '',
+        ];
+        snipeit_cache_set($cacheKey, ['ok' => true, 'data' => $out]);
+        return $out;
+    }
+}
+
+if (!function_exists('scan_txt_for_urls')) {
+    /**
+     * Read a Snipe-IT model .txt file and return its embedded URLs.
+     * Caches the URL list for 1h so we don't fetch the file twice per page.
+     * Returns empty array on any fetch error.
+     */
+    function scan_txt_for_urls(int $modelId, int $fileId): array
+    {
+        $cacheKey = 'txt_urls_' . $modelId . '_' . $fileId;
+        $cached = snipeit_cache_get($cacheKey, 3600);
+        if ($cached !== null) {
+            return is_array($cached) ? $cached : [];
+        }
+        try {
+            [$ct, $cd, $body] = fetch_model_file($modelId, $fileId);
+            $urls = extract_urls_from_text($body);
+        } catch (Throwable $e) {
+            $urls = [];
+        }
+        snipeit_cache_set($cacheKey, $urls);
+        return $urls;
+    }
+}

--- a/src/snipeit_client.php
+++ b/src/snipeit_client.php
@@ -449,6 +449,117 @@ function get_kit_models(int $kitId): array
 }
 
 /**
+ * Fetch files attached to a Snipe-IT model.
+ *
+ * Returns the raw row array from /api/v1/models/{id}/files. Each row's
+ * exact field set depends on Snipe-IT version, but typically includes
+ * id, filename (or name), url, size, created_at, notes.
+ *
+ * Cached 1h since model documentation changes infrequently.
+ */
+function get_model_files(int $modelId): array
+{
+    if ($modelId <= 0) {
+        throw new InvalidArgumentException('Invalid model ID');
+    }
+
+    $cacheKey = 'model_' . $modelId . '_files';
+    $cached = snipeit_cache_get($cacheKey, 3600);
+    if ($cached !== null) {
+        return $cached;
+    }
+
+    $data = snipeit_request('GET', 'models/' . $modelId . '/files');
+    $rows = isset($data['rows']) && is_array($data['rows']) ? $data['rows'] : [];
+
+    snipeit_cache_set($cacheKey, $rows);
+    return $rows;
+}
+
+/**
+ * Stream a Snipe-IT model file from the API.
+ *
+ * Returns [$contentType, $contentDisposition, $body] for a model file.
+ * Used by both the file proxy (for end-user downloads) and by the .txt
+ * URL scanner (which needs the body in memory). Not cached — proxy use
+ * is per-request and .txt scans cache at a higher layer.
+ *
+ * @return array{0:string,1:string,2:string}
+ * @throws Exception on HTTP error
+ */
+function fetch_model_file(int $modelId, int $fileId): array
+{
+    global $snipeBaseUrl, $snipeApiToken;
+    if ($modelId <= 0 || $fileId <= 0) {
+        throw new InvalidArgumentException('Invalid model/file ID');
+    }
+    if (!isset($snipeBaseUrl) || $snipeBaseUrl === '') {
+        $cfg = load_config();
+        $snipeBaseUrl  = rtrim($cfg['snipeit']['base_url'] ?? '', '/');
+        $snipeApiToken = $cfg['snipeit']['api_token'] ?? '';
+    }
+
+    $url = $snipeBaseUrl . '/api/v1/models/' . $modelId . '/files/' . $fileId;
+    $ch  = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, true);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Authorization: Bearer ' . $snipeApiToken,
+        'Accept: */*',
+    ]);
+    $response = curl_exec($ch);
+    if ($response === false) {
+        $err = curl_error($ch);
+        curl_close($ch);
+        throw new Exception("Snipe-IT file fetch failed: $err");
+    }
+    $code        = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $headerSize  = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    curl_close($ch);
+
+    if ($code !== 200) {
+        throw new Exception("Snipe-IT file fetch returned HTTP $code");
+    }
+
+    $headerBlob = substr($response, 0, $headerSize);
+    $body       = substr($response, $headerSize);
+
+    $contentType        = 'application/octet-stream';
+    $contentDisposition = '';
+    foreach (preg_split('/\r?\n/', $headerBlob) as $line) {
+        if (stripos($line, 'Content-Type:') === 0) {
+            $contentType = trim(substr($line, 13));
+        } elseif (stripos($line, 'Content-Disposition:') === 0) {
+            $contentDisposition = trim(substr($line, 20));
+        }
+    }
+
+    return [$contentType, $contentDisposition, $body];
+}
+
+/**
+ * Strip a wrapit.us QR URL down to its embedded asset_tag.
+ * Pass-through for any input that doesn't match the QR URL pattern.
+ *
+ * Why: QR labels carry "https://wrapit.us/v/{asset_tag}" so a USB scanner
+ * can type the same code a phone camera navigates to. POST handlers should
+ * run scanned input through this before treating it as a bare tag.
+ */
+function normalize_scanned_tag(string $value): string
+{
+    $s = trim($value);
+    if ($s === '') {
+        return '';
+    }
+    if (preg_match('#^https?://(?:www\.)?wrapit\.us/v/([^/\s?#]+)/?$#i', $s, $m)) {
+        return urldecode($m[1]);
+    }
+    return $s;
+}
+
+/**
  * Find a single asset by asset_tag.
  *
  * This uses the /hardware endpoint with a search, then looks for an


### PR DESCRIPTION
## Summary

Physical asset QR labels carry `https://wrapit.us/v/{asset_tag}` and now do double duty:

1. **USB barcode scanner** types the URL into a scan field; JS + PHP peel it back to the bare asset_tag.
2. **Phone camera** opens the URL in a browser; `public/v.php` renders a public per-model documentation page.

## Scanner URL handling

- `stripWrapitUrl()` in `public/assets/nav.js` (regex-strips on submit)
- `normalize_scanned_tag()` in `src/snipeit_client.php` (server-side safety net)
- Wired into `quick_checkin.php`, `quick_checkout.php`, `staff_checkout.php` (both `add_asset` and `scan_asset` modes)
- `basket.php` has no scan input, no changes needed

## `/v/{asset_tag}` page

- `public/v.php` — public (no auth). Looks up asset_tag → asset → model → files
- `public/v_file.php` — public file proxy (validates the file belongs to the model)
- `.txt` URL expansion (per the design choice):
  - `links.txt` — entries replace the .txt download (no .txt link rendered)
  - Other `.txt` — download stays, extracted URLs added underneath
- YouTube URLs (watch/shorts/embed/live/youtu.be) get thumbnail + title via oEmbed; capped at 10 lookups/page, cached 7d (success and failure)
- `src/qr_docs.php` houses the URL extraction, YouTube detection, oEmbed, and txt scanning helpers
- Bootstrap-icon icons per file type

## API helpers added (`src/snipeit_client.php`)

- `normalize_scanned_tag(string $value): string`
- `get_model_files(int $modelId): array` — wraps `/api/v1/models/{id}/files`, 1h cache (probed your install to confirm this endpoint exists)
- `fetch_model_file(int $modelId, int $fileId): array` — server-side authenticated fetch returning `[contentType, contentDisposition, body]`

## Deploy

`wrapit.us` is its own nginx vhost (no PHP-FPM there). Add this `location` block to `/etc/nginx/sites-enabled/wrapit.us.conf` and reload nginx:

```nginx
location ~* ^/v/([A-Za-z0-9._-]+)/?$ {
    return 302 https://ss.studio6h.com/v.php?tag=$1;
}
```

Browser users will land on `ss.studio6h.com/v.php?tag=…` after the 302 — that's fine for v1; you can flip the primary host later.

See `docs/qr-docs.md` for the full deploy + test checklist.

## Test plan

- [ ] Scan a QR with a USB barcode scanner on `quick_checkin.php`, `quick_checkout.php`, `staff_checkout.php` (both panels) — flash should show the bare tag, not the URL
- [ ] Add nginx redirect, reload nginx, browse `https://wrapit.us/v/{real-tag}` — should land on the docs page
- [ ] Upload a `links.txt` to a model in Snipe-IT with one URL per line including a YouTube link — `.txt` hidden, each URL rendered, YouTube one has thumb + title
- [ ] Upload a `setup-notes.txt` with prose containing a URL — `.txt` download stays, URL also extracted
- [ ] Asset tag with no parent model: renders 404
- [ ] Unknown tag: renders 404
