### PR TITLE
Dashboard Redesign and Catalogue Cards

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -142,6 +142,7 @@ return [
         'slot_capacity'         => 0,   // max checkouts+returns per slot (0 = unlimited)
         'cooldown_slots'        => 0,   // number of end-of-day slots with halved capacity (0 = disabled)
         'welcome_enabled'       => true, // show a welcome modal on first visit for new users
+        'suppress_manufacturers' => [], // manufacturer names hidden from catalogue cards (managed via settings UI)
     ],
 
     'reservations' => [

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -82,6 +82,7 @@
     /* Status */
     --status-info: #3b82f6;
     --status-success: #22c55e;
+    --status-success-rgb: 34, 197, 94;
     --badge-secondary: #5a6268;
     --badge-danger: #b02a37;
 
@@ -357,7 +358,7 @@ input[type="checkbox"] {
     display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
-    gap: 0.25rem;
+    gap: 1px;
     align-items: stretch;
     justify-content: flex-start;
     padding: calc((var(--topbar-height) - 1.3em) / 2) 0.75rem 2rem;
@@ -389,7 +390,7 @@ input[type="checkbox"] {
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: rgba(var(--white-rgb), 0.35);
-    padding: 0.9rem 0.75rem 0.25rem;
+    padding: 0.75rem 0.75rem 0.2rem;
 }
 
 .app-nav-brand,
@@ -405,55 +406,59 @@ input[type="checkbox"] {
     text-decoration: none;
 }
 
+.app-nav-alpha-tag {
+    display: block;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--alert-danger);
+    margin-top: 0.15rem;
+}
+
 .app-nav-link,
 .app-nav-link:visited {
-    padding: 0.3rem 0.75rem;
-    border-radius: 0.4rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: 0.44rem;
     text-decoration: none;
-    font-size: 0.92rem;
+    font-size: 0.82rem;
     font-weight: 500;
-    color: var(--white);
+    color: var(--muted);
     background: transparent;
     border: none;
     box-shadow: none;
     margin-left: 0 !important;
-    transition: background 0.15s ease;
+    transition: background 0.2s ease, color 0.2s ease;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.625rem;
 }
 
 .app-nav-icon {
-    font-size: 1rem;
-    opacity: 0.75;
+    font-size: 0.9rem;
     flex-shrink: 0;
     width: 1.1em;
     text-align: center;
 }
 
-.app-nav-link.active .app-nav-icon,
-.app-nav-link:hover .app-nav-icon {
-    opacity: 1;
-}
-
 .app-nav-link:hover {
-    background: rgba(var(--white-rgb), 0.15);
-    color: var(--white);
+    background: var(--surface-card);
+    color: var(--text);
     transform: none;
     box-shadow: none;
 }
 
 .app-nav-link:focus-visible {
-    background: rgba(var(--white-rgb), 0.15);
-    color: var(--white);
+    background: var(--surface-card);
+    color: var(--text);
     outline: 2px solid var(--white);
     outline-offset: 2px;
 }
 
 .app-nav-link.active {
-    background: rgba(var(--white-rgb), 0.15);
+    background: var(--surface-card);
     border-color: transparent;
-    color: var(--white);
+    color: var(--text);
     font-weight: 600;
     box-shadow: none;
 }
@@ -845,10 +850,6 @@ button.app-topbar-crumb--link {
     justify-content: center;
 }
 
-/* Hide view toggle while detail view is open */
-body[data-detail-open] .cat-topbar-view {
-    display: none;
-}
 
 /* Collapsible history panels in the detail view */
 .mh-panel {
@@ -1172,6 +1173,306 @@ body[data-detail-open] .cat-topbar-view {
     font-size: 0.85rem;
     color: var(--placeholder);
     text-align: center;
+}
+
+/* --------------------------------------------------
+   Catalogue card v2 (redesigned grid cards)
+   Scoped to .model-card-v2 so mobile list view is unaffected.
+-------------------------------------------------- */
+
+/* Override the base gradient and the global .card { background: var(--black) } rule.
+   Two-class selector (.card.model-card-v2) gives specificity (0,2,0) which beats
+   the single-class .card rule at (0,1,0) regardless of source order. */
+.card.model-card-v2 {
+    background: var(--surface);
+    --bs-card-bg: var(--surface);
+    overflow: hidden;
+    transition: border-color 0.2s;
+}
+
+.model-card-v2:hover {
+    border-color: rgba(var(--text-rgb), 0.5) !important;
+}
+
+/* Image area */
+.model-card-v2 .card-img-area {
+    position: relative;
+    height: 170px;
+    overflow: hidden;
+    border-radius: 0.9rem 0.9rem 0 0;
+    background: var(--bg);
+}
+
+.model-card-v2 .card-img-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+}
+
+.model-card-v2 .card-img-link .model-image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    transition: transform 0.3s ease;
+}
+
+.model-card-v2:hover .card-img-link .model-image {
+    transform: scale(1.06);
+}
+
+.model-card-v2 .card-img-link .model-image-placeholder {
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+
+.model-card-v2 .card-img-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.2s;
+    pointer-events: none;
+}
+
+/* overlay intentionally kept hidden — hover shows border outline + image zoom instead */
+
+.overlay-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text);
+    border: 1px solid rgba(var(--text-rgb), 0.3);
+    padding: 7px 16px;
+    border-radius: 7px;
+    backdrop-filter: blur(4px);
+}
+
+/* Meta row: category tag + availability badge */
+.model-card-v2 .card-meta-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.cat-tag {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.avail-badge {
+    font-size: 10px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 99px;
+}
+
+.avail-badge.avail-on {
+    background: rgba(var(--status-success-rgb), 0.12);
+    color: var(--status-success);
+}
+
+.avail-badge.avail-off {
+    background: rgba(var(--alert-danger-rgb), 0.12);
+    color: var(--alert-danger);
+}
+
+/* Item name (manufacturer prefix + model name on one line) */
+.model-card-v2 .card-name {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.3;
+    margin-bottom: 4px;
+}
+
+.card-manu-prefix {
+    color: var(--text);
+    font-weight: 400;
+}
+
+/* Notes / specs */
+.model-card-v2 .card-specs {
+    font-size: 11px;
+    color: var(--muted);
+    margin-bottom: 10px;
+}
+
+/* Footer */
+.model-card-v2 .card-footer-v2 {
+    padding: 10px 14px 12px;
+    background: var(--surface);
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.model-card-v2 .card-footer-v2 .card-actions-form {
+    margin: 0;
+    width: 100%;
+}
+
+.model-card-v2 .card-footer-v2 .card-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
+    width: 100%;
+}
+
+/* Mock-style buttons scoped to v2 cards */
+.card-btn-ghost {
+    background: var(--surface-card);
+    color: var(--text);
+    border: 1px solid var(--border);
+    font-size: 12px;
+    font-weight: 500;
+    padding: 5px 12px;
+    transition: border-color 0.15s, color 0.15s;
+}
+
+.card-btn-ghost:hover:not(:disabled) {
+    border-color: var(--muted);
+    color: var(--text);
+    background: var(--surface-card);
+}
+
+.card-btn-ghost:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.card-btn-primary {
+    background: var(--text);
+    color: var(--surface);
+    border: 1px solid transparent;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 5px 12px;
+    transition: opacity 0.15s;
+}
+
+.card-btn-primary:hover {
+    background: var(--text);
+    color: var(--surface);
+    opacity: 0.88;
+}
+
+/* No purple visited color, no highlight on hover */
+.model-card-v2 .model-history-link,
+.model-card-v2 .model-history-link:visited,
+.model-card-v2 .model-history-link:hover,
+.model-card-v2 .card-img-link,
+.model-card-v2 .card-img-link:visited,
+.model-card-v2 .card-img-link:hover {
+    color: var(--text);
+    text-decoration: none;
+}
+
+/* Split "Add to Basket | ▲ qty ▼" pill for multi-unit cards */
+.btn-qty-group {
+    display: inline-flex;
+    align-items: stretch;
+    background: var(--text);
+    border-radius: 0.25rem;
+    overflow: hidden;
+    height: 30px;
+}
+
+.btn-qty-add {
+    background: transparent;
+    color: var(--surface);
+    border: none;
+    padding: 0 11px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s;
+}
+
+.btn-qty-add:hover {
+    background: rgba(var(--black-rgb), 0.08);
+}
+
+.btn-qty-sep {
+    width: 1px;
+    background: rgba(var(--black-rgb), 0.18);
+    margin: 4px 0;
+    flex-shrink: 0;
+}
+
+.btn-qty-ctrl {
+    display: flex;
+    align-items: stretch;
+    width: 36px;
+    flex-shrink: 0;
+    overflow: hidden;
+}
+
+.btn-qty-num {
+    background: transparent;
+    border: none;
+    color: var(--surface);
+    flex: 1;
+    min-width: 0;
+    text-align: center;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 0;
+    outline: none;
+    -moz-appearance: textfield;
+}
+
+.btn-qty-num::-webkit-outer-spin-button,
+.btn-qty-num::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.btn-qty-arrows {
+    display: flex;
+    flex-direction: column;
+    width: 14px;
+    border-left: 1px solid rgba(var(--black-rgb), 0.15);
+}
+
+.btn-qty-arr {
+    background: transparent;
+    border: none;
+    color: var(--surface);
+    flex: 1;
+    padding: 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 7px;
+    opacity: 0.6;
+    transition: background 0.1s, opacity 0.1s;
+}
+
+.btn-qty-arr:hover {
+    background: rgba(var(--black-rgb), 0.1);
+    opacity: 1;
+}
+
+.btn-qty-up {
+    border-bottom: 1px solid rgba(var(--black-rgb), 0.12);
+}
+
+/* Extend whole-card overlay to new card structure */
+.model-card-v2 .model-history-link::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: inherit;
 }
 
 /* Thumbnails for reservation checkout model selector */
@@ -3396,21 +3697,15 @@ body.page-catalogue {
     .app-nav.app-nav--expanded .app-nav-link,
     .app-nav.app-nav--expanded .app-nav-link:visited {
         justify-content: flex-start;
-        padding: 0.3rem 0.75rem;
-        gap: 0.5rem;
+        padding: 0.5rem 0.625rem;
+        gap: 0.625rem;
         min-height: unset;
         min-width: unset;
     }
 
     .app-nav.app-nav--expanded .app-nav-icon {
-        font-size: 1rem;
-        opacity: 0.75;
+        font-size: 0.9rem;
         width: 1.1em;
-    }
-
-    .app-nav.app-nav--expanded .app-nav-link.active .app-nav-icon,
-    .app-nav.app-nav--expanded .app-nav-link:hover .app-nav-icon {
-        opacity: 1;
     }
 }
 
@@ -3482,20 +3777,14 @@ body.page-catalogue {
     .app-nav-link,
     .app-nav-link:visited {
         justify-content: flex-start;
-        padding: 0.3rem 0.75rem;
+        padding: 0.5rem 0.625rem;
         min-height: 44px;
-        gap: 0.5rem;
+        gap: 0.625rem;
     }
 
     .app-nav-icon {
-        font-size: 1rem;
-        opacity: 0.75;
+        font-size: 0.9rem;
         width: 1.1em;
-    }
-
-    .app-nav-link.active .app-nav-icon,
-    .app-nav-link:hover .app-nav-icon {
-        opacity: 1;
     }
 }
 
@@ -4200,155 +4489,7 @@ body.page-catalogue {
     min-width: 0;
 }
 
-/* Sidebar view toggle: visible on desktop, side-by-side with sort */
-.cat-view-dropdown {
-    display: block;
-    position: relative;
-}
 
-/* Shrink controls to fit side-by-side in the narrow sidebar */
-.cat-sort-view-row .cat-toggle-btn {
-    font-size: 0.8rem;
-    padding: 0.28rem 0.45rem;
-}
-
-.cat-sort-view-row .form-label {
-    font-size: 0.75rem;
-}
-
-.catalogue-filter-sidebar .cat-sort-view-row .cat-rounded-select {
-    font-size: 0.8rem;
-    padding-left: 0.45rem;
-    padding-right: 1.5rem;
-}
-
-/* Mobile: topbar toggle hidden (sidebar toggle replaces it) */
-@media (max-width: 599px) {
-    .cat-topbar-view {
-        display: none !important;
-    }
-}
-
-/* ---- View toggle dropdown menu (absolute — does not push content) ---- */
-.cat-view-menu {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    min-width: 110px;
-    z-index: 300;
-    background: var(--cat-option-bg);
-    border: 1px solid var(--border);
-    border-top: none;
-    border-radius: 0 0 0.5rem 0.5rem;
-    overflow: hidden;
-}
-
-.cat-view-toggle[aria-expanded="true"] {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-}
-
-/* Sidebar option buttons inherit .cat-option styles; topbar options need their own */
-.cat-view-option {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.45rem 0.75rem;
-    cursor: pointer;
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: var(--text);
-    background: transparent;
-    border: none;
-    width: 100%;
-    text-align: left;
-    white-space: nowrap;
-}
-
-.cat-view-option+.cat-view-option {
-    border-top: 1px solid var(--border);
-}
-
-.cat-view-option:hover {
-    background: var(--cat-option-hover-bg);
-}
-
-.cat-view-option:focus-visible {
-    outline: 2px solid var(--primary);
-    outline-offset: -2px;
-}
-
-.cat-view-option.active {
-    background: rgba(var(--primary-rgb), 0.14);
-    color: var(--primary);
-    font-weight: 700;
-}
-
-/* ---- Topbar view toggle (desktop) — hidden; toggle moved to sidebar ---- */
-.cat-topbar-view {
-    display: none;
-}
-
-.cat-topbar-view-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.28rem 0.6rem;
-    background: rgba(var(--white-rgb), 0.08);
-    border: 1px solid rgba(var(--white-rgb), 0.2);
-    border-radius: 0.4rem;
-    color: var(--white);
-    font-size: 0.82rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.15s ease;
-    white-space: nowrap;
-    line-height: 1.4;
-}
-
-.cat-topbar-view-btn:hover {
-    background: rgba(var(--white-rgb), 0.15);
-    border-color: rgba(var(--white-rgb), 0.35);
-}
-
-.cat-topbar-view-btn:focus-visible {
-    outline: 2px solid var(--white);
-    outline-offset: 2px;
-}
-
-.cat-topbar-view-btn[aria-expanded="true"] {
-    background: rgba(var(--white-rgb), 0.12);
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-}
-
-/* Topbar dropdown: darker colours to match the black topbar */
-.cat-topbar-view .cat-view-menu {
-    background: var(--surface-deep);
-    border-color: rgba(var(--white-rgb), 0.18);
-}
-
-.cat-topbar-view .cat-view-option {
-    color: var(--window-modal-slot-text);
-}
-
-.cat-topbar-view .cat-view-option+.cat-view-option {
-    border-top-color: rgba(var(--white-rgb), 0.1);
-}
-
-.cat-topbar-view .cat-view-option:hover {
-    background: rgba(var(--white-rgb), 0.1);
-}
-
-.cat-topbar-view .cat-view-option:focus-visible {
-    outline: 2px solid rgba(var(--white-rgb), 0.8);
-    outline-offset: -2px;
-}
-
-.cat-topbar-view .cat-view-option.active {
-    background: rgba(var(--primary-rgb), 0.35);
-    color: var(--white);
-}
 
 /* Sidebar user suggestions — allow popover to grow wider than the input */
 .cat-sidebar-user-card #booking_user_suggestions {
@@ -4357,7 +4498,7 @@ body.page-catalogue {
     min-width: 0;
 }
 
-/* ---- New wrapper base styles (grid view) ---- */
+/* ---- Catalogue card base styles (desktop grid) ---- */
 
 /* model-nameline and model-card-right are layout helpers; in grid view they
    act as transparent pass-through containers via display:contents */
@@ -4369,7 +4510,7 @@ body.page-catalogue {
     display: contents;
 }
 
-/* Manufacturer span: block element below the title in grid view (base/v1 fallback) */
+/* Manufacturer span: block element below the title in grid view */
 .model-meta-manufacturer {
     display: block;
     font-size: 1rem;
@@ -4380,23 +4521,23 @@ body.page-catalogue {
     display: none;
 }
 
-/* Grid view: divider below name section — on card-title by default,
+/* Divider below name section — on card-title by default,
    moves to manufacturer span when one is present. */
-.catalogue-scroll-area[data-catalogue-view="grid"] .card-title,
-.catalogue-scroll-area[data-catalogue-view="grid"] .model-meta-manufacturer {
+.catalogue-scroll-area .card-title,
+.catalogue-scroll-area .model-meta-manufacturer {
     border-bottom: 1px solid var(--border);
     padding-bottom: 0.55rem;
     margin-bottom: 0.5rem;
 }
 
-.catalogue-scroll-area[data-catalogue-view="grid"] .card-title:has(+ .model-meta-manufacturer) {
+.catalogue-scroll-area .card-title:has(+ .model-meta-manufacturer) {
     border-bottom: none;
     padding-bottom: 0;
     margin-bottom: 0;
 }
 
-/* Grid view: add-to-basket button left, quantity input right */
-.catalogue-scroll-area[data-catalogue-view="grid"] .add-to-basket-form {
+/* add-to-basket button left, quantity input right */
+.catalogue-scroll-area .add-to-basket-form {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -4404,178 +4545,47 @@ body.page-catalogue {
     flex-wrap: wrap;
 }
 
-.catalogue-scroll-area[data-catalogue-view="grid"] .add-to-basket-form .row.g-2 {
+.catalogue-scroll-area .add-to-basket-form .row.g-2 {
     flex: 0 0 auto;
     margin: 0;
     order: 2;
 }
 
-.catalogue-scroll-area[data-catalogue-view="grid"] .add-to-basket-form .col-6 {
+.catalogue-scroll-area .add-to-basket-form .col-6 {
     flex: unset;
     width: auto;
     padding: 0;
 }
 
-.catalogue-scroll-area[data-catalogue-view="grid"] .add-to-basket-form label {
+.catalogue-scroll-area .add-to-basket-form label {
     display: none;
 }
 
-.catalogue-scroll-area[data-catalogue-view="grid"] .add-to-basket-form input[name="quantity"] {
+.catalogue-scroll-area .add-to-basket-form input[name="quantity"] {
     width: 58px;
     text-align: center;
 }
 
-.catalogue-scroll-area[data-catalogue-view="grid"] .add-to-basket-form .btn-success {
+.catalogue-scroll-area .add-to-basket-form .btn-success {
     flex: 1 0 auto;
     width: auto !important;
     order: 1;
 }
 
-/* Availability div: small muted text just above the form in grid view */
+/* Availability div: small muted text above the form */
 .model-meta-availability {
     font-size: 0.8rem;
     color: var(--muted);
     margin-bottom: 0.25rem;
 }
 
-/* Grid view: requestable/available side by side with extra spacing */
-.catalogue-scroll-area[data-catalogue-view="grid"] .model-meta-availability {
+/* Requestable/available side by side */
+.catalogue-scroll-area .model-meta-availability {
     display: flex;
     flex-direction: row;
     gap: 1rem;
     flex-wrap: wrap;
     margin-bottom: 0.5rem;
-}
-
-/* ---- Catalogue list view ---- */
-
-/* Outer padding */
-.catalogue-scroll-area[data-catalogue-view="list"] {
-    padding: 1.5rem;
-}
-
-/* Full-width rows — zero out Bootstrap's g-3 gutter margin (--bs-gutter-y)
-   so it doesn't stack on top of our gap */
-.catalogue-scroll-area[data-catalogue-view="list"] .row.g-3 {
-    --bs-gutter-y: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.8rem;
-}
-
-.catalogue-scroll-area[data-catalogue-view="list"] .col-md-4 {
-    width: 100%;
-    max-width: 100%;
-    flex: 0 0 100%;
-    padding: 0;
-}
-
-/* Card: horizontal row, solid black, border only — no gradient, no shadow */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-card {
-    flex-direction: row;
-    align-items: stretch;
-    background: var(--black);
-    box-shadow: none;
-    border-radius: 0.5rem;
-}
-
-/* Thumbnail: fixed square, image fills it with contain */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-image-wrapper,
-.catalogue-scroll-area[data-catalogue-view="list"] .model-image-wrapper--placeholder {
-    width: 110px;
-    min-width: 110px;
-    height: 110px;
-    flex-shrink: 0;
-    align-self: center;
-    border-bottom: none;
-    border-right: 1px solid var(--border-image-sep);
-    border-radius: 0.5rem 0 0 0.5rem;
-    padding: 8px 0 8px 8px;
-    overflow: hidden;
-}
-
-/* Image fills the square, scales to fit while keeping aspect ratio */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-image {
-    width: 100%;
-    height: 100%;
-    max-width: unset;
-    max-height: unset;
-    object-fit: contain;
-}
-
-/* Card body: CSS grid — content left, actions right.
-   !important beats Bootstrap's d-flex utility class. */
-.catalogue-scroll-area[data-catalogue-view="list"] .card-body {
-    flex: 1;
-    min-width: 0;
-    display: grid !important;
-    grid-template-columns: 1fr 210px;
-    grid-template-rows: auto 1fr auto;
-    padding: 0.55rem 0;
-    align-items: start;
-}
-
-/* Row 1: item name + manufacturer inline */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-nameline {
-    display: flex;
-    align-items: baseline;
-    gap: 0.55rem;
-    grid-column: 1;
-    grid-row: 1;
-    min-width: 0;
-    padding: 0 1rem;
-}
-
-.catalogue-scroll-area[data-catalogue-view="list"] .card-title {
-    font-size: 1.15rem;
-    font-weight: 600;
-    margin-bottom: 0;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    flex-shrink: 1;
-}
-
-/* Manufacturer: greyer, smaller, inline */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-meta-manufacturer {
-    display: inline;
-    font-size: 0.95rem;
-    color: var(--muted);
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-
-.catalogue-scroll-area[data-catalogue-view="list"] .model-meta-manufacturer strong {
-    display: none;
-}
-
-/* Row 2: notes */
-.catalogue-scroll-area[data-catalogue-view="list"] .card-text {
-    grid-column: 1;
-    grid-row: 2;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    margin-bottom: 0;
-    padding: 0.2rem 1rem 0.3rem;
-}
-
-/* Notes: white, 2-line clamp */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-meta-notes {
-    color: var(--text);
-    font-size: 0.82rem;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-}
-
-/* Row 3: tag pills (category + certs + access levels) */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-card-tags {
-    grid-column: 1;
-    grid-row: 3;
-    padding: 0 1rem 0.55rem;
 }
 
 /* Base pill style shared by all tag types */
@@ -4636,156 +4646,146 @@ body.page-catalogue {
     opacity: 0.45;
 }
 
-/* Right panel: availability + qty+button row, vertically centred */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-card-right {
-    grid-column: 2;
-    grid-row: 1 / span 3;
-    display: flex !important;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    justify-self: center;
-    align-self: stretch;
-    gap: 0.55rem;
-    padding: 0.55rem 1rem;
-    text-align: center;
-}
-
-/* Availability counts: centred, stacked */
-.catalogue-scroll-area[data-catalogue-view="list"] .model-meta-availability {
-    display: flex;
-    flex-direction: column;
-    gap: 0.05rem;
-    font-size: 0.8rem;
-    color: var(--muted);
-    text-align: center;
-    line-height: 1.5;
-    flex: 1;
-    justify-content: center;
-}
-
-.catalogue-scroll-area[data-catalogue-view="list"] .model-meta-requestable,
-.catalogue-scroll-area[data-catalogue-view="list"] .model-meta-available {
-    display: flex;
-    align-items: center;
-}
-
-/* Form: the form itself becomes a flex row so qty div + button sit side by side */
-.catalogue-scroll-area[data-catalogue-view="list"] .add-to-basket-form {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 0.4rem;
-    margin-top: 0;
-    width: 100%;
-}
-
-/* Qty wrapper: shrink-wrap the input, placed to the right of the button */
-.catalogue-scroll-area[data-catalogue-view="list"] .add-to-basket-form .row.g-2 {
-    flex: 0 0 auto;
-    display: block;
-    margin: 0;
-    padding: 0;
-    width: auto;
-    order: 2;
-}
-
-.catalogue-scroll-area[data-catalogue-view="list"] .add-to-basket-form .col-6 {
-    flex: unset;
-    width: auto;
-    padding: 0;
-}
-
-/* Hide the Quantity label */
-.catalogue-scroll-area[data-catalogue-view="list"] .add-to-basket-form label {
-    display: none;
-}
-
-/* Qty input: compact fixed width */
-.catalogue-scroll-area[data-catalogue-view="list"] .add-to-basket-form input[name="quantity"] {
-    width: 58px;
-    text-align: center;
-}
-
-/* Hide disabled (access/cert blocked) add-to-basket buttons — v2 shows only the warning alert */
+/* Hide disabled (access/cert blocked) add-to-basket buttons */
 .add-to-basket-form button[disabled] {
     display: none;
 }
 
-/* Hide the entire form unless it has an enabled button */
-.catalogue-scroll-area[data-catalogue-view="list"] .add-to-basket-form:not(:has(button:not([disabled]))) {
-    display: none !important;
-}
-
-/* Add to basket button: bigger, fills remaining width, placed left of qty */
-.catalogue-scroll-area[data-catalogue-view="list"] .add-to-basket-form .btn-success {
-    flex: 1;
-    width: auto !important;
-    order: 1;
-    padding: 0.4rem 0.8rem;
-    font-size: 0.85rem;
-    white-space: nowrap;
-}
-
-
-/* Mobile: keep horizontal row, collapse right panel below title */
+/* ---- Catalogue list view (mobile ≤ 767px) ---- */
 @media (max-width: 767px) {
-    .catalogue-scroll-area[data-catalogue-view="list"] .model-card {
+    .catalogue-scroll-area {
+        padding: 1.5rem;
+    }
+
+    .catalogue-scroll-area .row.g-3 {
+        --bs-gutter-y: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+    }
+
+    .catalogue-scroll-area .col-md-4 {
+        width: 100%;
+        max-width: 100%;
+        flex: 0 0 100%;
+        padding: 0;
+    }
+
+    .catalogue-scroll-area .model-card {
         flex-direction: row;
         align-items: stretch;
+        background: var(--black);
+        box-shadow: none;
+        border-radius: 0.5rem;
         overflow: hidden;
     }
 
-    .catalogue-scroll-area[data-catalogue-view="list"] .model-image-wrapper,
-    .catalogue-scroll-area[data-catalogue-view="list"] .model-image-wrapper--placeholder {
+    .catalogue-scroll-area .model-image-wrapper,
+    .catalogue-scroll-area .model-image-wrapper--placeholder {
         width: 80px;
         min-width: 80px;
         height: auto;
+        flex-shrink: 0;
         align-self: stretch;
-        border-right: 1px solid var(--border-image-sep);
         border-bottom: none;
+        border-right: 1px solid var(--border-image-sep);
         border-radius: 0.5rem 0 0 0.5rem;
         padding: 6px 0 6px 6px;
+        overflow: hidden;
+    }
+
+    .catalogue-scroll-area .model-image {
+        width: 100%;
+        height: 100%;
+        max-width: unset;
+        max-height: unset;
+        object-fit: contain;
     }
 
     /* Single-column grid: title → notes → tags → actions */
-    .catalogue-scroll-area[data-catalogue-view="list"] .card-body {
+    .catalogue-scroll-area .card-body {
+        flex: 1;
+        min-width: 0;
         display: grid !important;
         grid-template-columns: minmax(0, 1fr);
         grid-template-rows: auto auto auto auto;
         padding: 0.5rem 0;
         align-items: start;
-        min-width: 0;
     }
 
-    .catalogue-scroll-area[data-catalogue-view="list"] .model-nameline {
+    /* Reset desktop grid-view title border */
+    .catalogue-scroll-area .card-title,
+    .catalogue-scroll-area .model-meta-manufacturer {
+        border-bottom: none;
+        padding-bottom: 0;
+        margin-bottom: 0;
+    }
+
+    .catalogue-scroll-area .model-nameline {
+        display: flex;
+        align-items: baseline;
+        gap: 0.55rem;
         grid-column: 1;
         grid-row: 1;
         min-width: 0;
+        padding: 0 1rem;
     }
 
-    /* Manufacturer shrinks before the model name */
-    .catalogue-scroll-area[data-catalogue-view="list"] .model-meta-manufacturer {
+    .catalogue-scroll-area .card-title {
+        font-size: 1.15rem;
+        font-weight: 600;
+        margin-bottom: 0;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        flex-shrink: 1;
+    }
+
+    .catalogue-scroll-area .model-meta-manufacturer {
+        display: inline;
+        font-size: 0.95rem;
+        color: var(--muted);
+        white-space: nowrap;
         flex-shrink: 5;
         min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
     }
 
-    .catalogue-scroll-area[data-catalogue-view="list"] .card-text {
+    .catalogue-scroll-area .model-meta-manufacturer strong {
+        display: none;
+    }
+
+    .catalogue-scroll-area .card-text {
         grid-column: 1;
         grid-row: 2;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        margin-bottom: 0;
+        padding: 0.2rem 1rem 0.3rem;
         min-width: 0;
     }
 
-    .catalogue-scroll-area[data-catalogue-view="list"] .model-card-tags {
+    .catalogue-scroll-area .model-meta-notes {
+        color: var(--text);
+        font-size: 0.82rem;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+    }
+
+    .catalogue-scroll-area .model-card-tags {
         grid-column: 1;
         grid-row: 3;
+        padding: 0 1rem 0.55rem;
         min-width: 0;
     }
 
-    /* Actions row: availability left, form right; wraps to stack when narrow */
-    .catalogue-scroll-area[data-catalogue-view="list"] .model-card-right {
+    /* Actions row: availability left, form right */
+    .catalogue-scroll-area .model-card-right {
         grid-column: 1;
         grid-row: 4;
         display: flex !important;
@@ -4802,20 +4802,72 @@ body.page-catalogue {
         gap: 0.5rem;
     }
 
-    /* Availability counts: left side of the actions row */
-    .catalogue-scroll-area[data-catalogue-view="list"] .model-meta-availability {
+    .catalogue-scroll-area .model-meta-availability {
+        display: flex;
         flex-direction: row;
         flex-wrap: wrap;
         gap: 0.3rem 0.5rem;
         flex: 0 1 auto;
         min-width: 0;
+        margin-bottom: 0;
+        font-size: 0.8rem;
+        color: var(--muted);
+        text-align: left;
+        line-height: 1.5;
     }
 
-    /* Form: right side; shrinks but doesn't overflow */
-    .catalogue-scroll-area[data-catalogue-view="list"] .add-to-basket-form {
+    .catalogue-scroll-area .model-meta-requestable,
+    .catalogue-scroll-area .model-meta-available {
+        display: flex;
+        align-items: center;
+    }
+
+    .catalogue-scroll-area .add-to-basket-form {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 0.4rem;
+        margin-top: 0;
         flex: 0 1 auto;
         min-width: 0;
         flex-wrap: nowrap;
+    }
+
+    .catalogue-scroll-area .add-to-basket-form .row.g-2 {
+        flex: 0 0 auto;
+        display: block;
+        margin: 0;
+        padding: 0;
+        width: auto;
+        order: 2;
+    }
+
+    .catalogue-scroll-area .add-to-basket-form .col-6 {
+        flex: unset;
+        width: auto;
+        padding: 0;
+    }
+
+    .catalogue-scroll-area .add-to-basket-form label {
+        display: none;
+    }
+
+    .catalogue-scroll-area .add-to-basket-form input[name="quantity"] {
+        width: 58px;
+        text-align: center;
+    }
+
+    .catalogue-scroll-area .add-to-basket-form:not(:has(button:not([disabled]))) {
+        display: none !important;
+    }
+
+    .catalogue-scroll-area .add-to-basket-form .btn-success {
+        flex: 1;
+        width: auto !important;
+        order: 1;
+        padding: 0.4rem 0.8rem;
+        font-size: 0.85rem;
+        white-space: nowrap;
     }
 }
 

--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -962,7 +962,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
 
             <div class="row g-3 align-items-end">
 
-                <!-- Sort + View toggle row, then Categories -->
+                <!-- Sort row, then Categories -->
                 <div class="col-12">
                     <div class="cat-sort-view-row">
                         <div class="cat-sort-item">
@@ -976,21 +976,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                                 <option value="units_desc" <?= $sort === 'units_desc' ? 'selected' : '' ?>>Units (high–low)</option>
                             </select>
                         </div>
-                        <div class="cat-sort-item cat-view-dropdown">
-                            <label class="form-label mb-1 fw-semibold">View</label>
-                            <button type="button" class="cat-toggle-btn cat-view-toggle" id="cat-view-btn-side"
-                                    aria-haspopup="true" aria-expanded="false">
-                                <i class="bi bi-list-ul" id="cat-view-icon-side" aria-hidden="true"></i>
-                                <span id="cat-view-label-side">List</span>
-                                <svg class="cat-toggle-chevron ms-auto" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                                    <path d="M2 4l4 4 4-4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-                                </svg>
-                            </button>
-                            <div class="cat-view-menu cat-dropdown" id="cat-view-menu-side" hidden>
-                                <button type="button" class="cat-view-option cat-option" data-view="list"><i class="bi bi-list-ul" aria-hidden="true"></i> List</button>
-                                <button type="button" class="cat-view-option cat-option" data-view="grid"><i class="bi bi-grid" aria-hidden="true"></i> Grid</button>
-                            </div>
-                        </div>
+
                     </div>
                 </div>
 
@@ -1065,21 +1051,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                                 <option value="units_desc" <?= $sort === 'units_desc' ? 'selected' : '' ?>>Units (high–low)</option>
                             </select>
                         </div>
-                        <div class="cat-mobile-filter-item cat-view-dropdown">
-                            <label class="form-label mb-1 fw-semibold">View</label>
-                            <button type="button" class="cat-toggle-btn cat-view-toggle" id="cat-view-btn-mobile"
-                                    aria-haspopup="true" aria-expanded="false">
-                                <i class="bi bi-list-ul" id="cat-view-icon-mobile" aria-hidden="true"></i>
-                                <span id="cat-view-label-mobile">List</span>
-                                <svg class="cat-toggle-chevron ms-auto" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                                    <path d="M2 4l4 4 4-4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-                                </svg>
-                            </button>
-                            <div class="cat-view-menu cat-dropdown" id="cat-view-menu-mobile" hidden>
-                                <button type="button" class="cat-view-option cat-option" data-view="list"><i class="bi bi-list-ul" aria-hidden="true"></i> List</button>
-                                <button type="button" class="cat-view-option cat-option" data-view="grid"><i class="bi bi-grid" aria-hidden="true"></i> Grid</button>
-                            </div>
-                        </div>
+
                     </div>
                     <div class="mt-2">
                         <p class="form-label mb-1 fw-semibold" id="cat-mobile-cat-label">Category</p>
@@ -1123,6 +1095,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
             <?php
                 $displayedModelIds = array_map(fn($m) => (int)($m['id'] ?? 0), $models);
                 $modelStats = prefetch_catalogue_model_stats($displayedModelIds);
+                $suppressedManus = array_map('strtolower', $config['app']['suppress_manufacturers'] ?? []);
             ?>
             <div class="row g-3">
                 <?php foreach ($models as $model): ?>
@@ -1136,6 +1109,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
 
                     $name       = $model['name'] ?? 'Model';
                     $manuName   = $model['manufacturer']['name'] ?? '';
+                    $showManu   = $manuName !== '' && !in_array(strtolower($manuName), $suppressedManus, true);
                     $catName    = $model['category']['name'] ?? '';
                     $imagePath  = $model['image'] ?? '';
                     $assetCount = null;
@@ -1259,139 +1233,117 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                         $proxiedImage = 'image_proxy.php?src=' . urlencode($imagePath);
                     }
                     ?>
+                    <?php
+                        $undeployInfo = $bulkStats ? $bulkStats['undeployable'] : ['undeployable_count' => 0, 'status_names' => []];
+                        $uCount    = $undeployInfo['undeployable_count'];
+                        $uStatuses = $uCount > 0 ? implode(', ', $undeployInfo['status_names']) : '';
+                        if ($assetCount !== null && $freeNow <= 0) $availDotClass = 'model-avail-dot--red';
+                        elseif ($assetCount !== null && $freeNow < $assetCount) $availDotClass = 'model-avail-dot--yellow';
+                        else $availDotClass = 'model-avail-dot--green';
+                    ?>
                     <div class="col-md-4">
-                        <div class="card h-100 model-card<?= ($isRequestable && $freeNow > 0) ? '' : ' model-card--unavailable' ?>">
-                            <?php if ($proxiedImage !== ''): ?>
-                                <div class="model-image-wrapper">
-                                    <a href="#" onclick="openModelDetail(<?= (int)$modelId ?>, <?= htmlspecialchars(json_encode($name), ENT_QUOTES) ?>); return false;">
-                                        <img src="<?= htmlspecialchars($proxiedImage) ?>"
-                                             alt=""
-                                             class="model-image img-fluid">
-                                    </a>
-                                </div>
-                            <?php else: ?>
-                                <div class="model-image-wrapper model-image-wrapper--placeholder">
-                                    <a href="#" onclick="openModelDetail(<?= (int)$modelId ?>, <?= htmlspecialchars(json_encode($name), ENT_QUOTES) ?>); return false;">
-                                        <div class="model-image-placeholder">
-                                            No image
-                                        </div>
-                                    </a>
-                                </div>
-                            <?php endif; ?>
+                        <div class="card h-100 model-card model-card-v2<?= ($isRequestable && $freeNow > 0) ? '' : ' model-card--unavailable' ?>">
 
-                            <?php
-                                $undeployInfo = $bulkStats ? $bulkStats['undeployable'] : ['undeployable_count' => 0, 'status_names' => []];
-                                $uCount   = $undeployInfo['undeployable_count'];
-                                $uStatuses = $uCount > 0 ? implode(', ', $undeployInfo['status_names']) : '';
-                            ?>
+                            <!-- Image area -->
+                            <div class="card-img-area">
+                                <a href="#" class="card-img-link"
+                                   onclick="openModelDetail(<?= (int)$modelId ?>, <?= htmlspecialchars(json_encode($name), ENT_QUOTES) ?>); return false;">
+                                    <?php if ($proxiedImage !== ''): ?>
+                                        <img src="<?= htmlspecialchars($proxiedImage) ?>" alt="" class="model-image">
+                                    <?php else: ?>
+                                        <div class="model-image-placeholder">No image</div>
+                                    <?php endif; ?>
+                                </a>
+                                <div class="card-img-overlay">
+                                    <div class="overlay-label">View Details</div>
+                                </div>
+                            </div>
+
+                            <!-- Card body -->
                             <div class="card-body d-flex flex-column">
-                                <div class="model-nameline">
-                                    <h5 class="card-title">
-                                        <a href="#" class="model-history-link" onclick="openModelDetail(<?= (int)$modelId ?>, <?= htmlspecialchars(json_encode($name), ENT_QUOTES) ?>); return false;">
-                                            <?= label_safe($name) ?>
-                                        </a>
-                                    </h5>
-                                    <?php if ($manuName): ?>
-                                        <span class="model-meta-manufacturer"><strong>Manufacturer:</strong> <?= label_safe($manuName) ?></span>
-                                    <?php endif; ?>
-                                </div>
-                                <?php if (!empty($notes)): ?>
-                                <p class="card-text small text-muted mb-2">
-                                    <div class="model-meta-notes clamp-3">
-                                        <?= label_safe($notes) ?>
-                                    </div>
-                                </p>
-                                <?php endif; ?>
 
-                                <?php if ($catName || !empty($authReqs['certs']) || !empty($authReqs['access_levels']) || $uCount > 0): ?>
-                                <div class="model-card-tags">
+                                <!-- Category + availability badge -->
+                                <div class="card-meta-row">
                                     <?php if ($catName): ?>
-                                        <span class="model-meta-category"><?= label_safe($catName) ?></span>
+                                        <span class="cat-tag"><?= label_safe($catName) ?></span>
                                     <?php endif; ?>
-                                    <?php foreach ($authReqs['certs'] as $certName): ?>
-                                        <span class="model-cert-tag"><?= h($certName) ?></span>
-                                    <?php endforeach; ?>
-                                    <?php foreach ($authReqs['access_levels'] as $level): ?>
-                                        <span class="model-access-tag"><?= h($level) ?></span>
-                                    <?php endforeach; ?>
-                                    <?php if ($uCount > 0): ?>
-                                        <span class="model-unavailable-tag" title="<?= h($uStatuses) ?>"><?= $uCount ?> unit<?= $uCount !== 1 ? 's' : '' ?> unavailable</span>
-                                    <?php endif; ?>
+                                    <span class="avail-badge <?= $freeNow > 0 ? 'avail-on' : 'avail-off' ?>">
+                                        <?= $freeNow > 0 ? 'Available' : 'Out' ?>
+                                    </span>
                                 </div>
+
+                                <!-- Name (with optional manufacturer prefix on same line) -->
+                                <div class="card-name model-nameline">
+                                    <a href="#" class="model-history-link"
+                                       onclick="openModelDetail(<?= (int)$modelId ?>, <?= htmlspecialchars(json_encode($name), ENT_QUOTES) ?>); return false;"><?php if ($showManu): ?><span class="card-manu-prefix"><?= label_safe($manuName) ?></span> <?php endif; ?><?= label_safe($name) ?></a>
+                                </div>
+
+                                <!-- Notes / specs -->
+                                <?php if (!empty($notes)): ?>
+                                    <div class="card-specs clamp-2"><?= label_safe($notes) ?></div>
                                 <?php endif; ?>
 
-                                <div class="model-card-right">
-                                    <div class="model-meta-availability">
-                                        <?php
-                                        if ($assetCount !== null && $freeNow <= 0) $availDotClass = 'model-avail-dot--red';
-                                        elseif ($assetCount !== null && $freeNow < $assetCount) $availDotClass = 'model-avail-dot--yellow';
-                                        else $availDotClass = 'model-avail-dot--green';
-                                        ?>
-                                        <?php if ($assetCount !== null): ?>
-                                            <span class="model-meta-requestable"><span class="model-avail-dot model-avail-dot--green"></span><strong>Requestable:</strong> <?= $assetCount ?></span>
+                                <!-- Cert / access / unavailable tags -->
+                                <?php if (!empty($authReqs['certs']) || !empty($authReqs['access_levels']) || $uCount > 0): ?>
+                                    <div class="model-card-tags">
+                                        <?php foreach ($authReqs['certs'] as $certName): ?>
+                                            <span class="model-cert-tag"><?= h($certName) ?></span>
+                                        <?php endforeach; ?>
+                                        <?php foreach ($authReqs['access_levels'] as $level): ?>
+                                            <span class="model-access-tag"><?= h($level) ?></span>
+                                        <?php endforeach; ?>
+                                        <?php if ($uCount > 0): ?>
+                                            <span class="model-unavailable-tag" title="<?= h($uStatuses) ?>"><?= $uCount ?> unit<?= $uCount !== 1 ? 's' : '' ?> unavailable</span>
                                         <?php endif; ?>
-                                        <span class="model-meta-available"><span class="model-avail-dot <?= $availDotClass ?>"></span><strong><?= $windowActive ? 'Available (dates):' : 'Available:' ?></strong> <?= $freeNow ?></span>
                                     </div>
-                                    <form method="post"
-                                          action="basket_add.php"
-                                          class="mt-auto add-to-basket-form">
-                                        <input type="hidden" name="model_id" value="<?= $modelId ?>">
-                                        <?php if ($windowActive): ?>
-                                            <input type="hidden" name="start_datetime" value="<?= h($windowStartRaw) ?>">
-                                            <input type="hidden" name="end_datetime" value="<?= h($windowEndRaw) ?>">
-                                        <?php endif; ?>
+                                <?php endif; ?>
+
+                            </div>
+
+                            <!-- Card footer -->
+                            <div class="card-footer-v2">
+                                <form method="post" action="basket_add.php"
+                                      class="add-to-basket-form card-actions-form">
+                                    <input type="hidden" name="model_id" value="<?= $modelId ?>">
+                                    <?php if ($windowActive): ?>
+                                        <input type="hidden" name="start_datetime" value="<?= h($windowStartRaw) ?>">
+                                        <input type="hidden" name="end_datetime" value="<?= h($windowEndRaw) ?>">
+                                    <?php endif; ?>
+                                    <div class="card-actions">
+                                        <button type="button" class="btn card-btn-ghost btn-sm"
+                                                onclick="openModelDetail(<?= (int)$modelId ?>, <?= htmlspecialchars(json_encode($name), ENT_QUOTES) ?>)">Details</button>
 
                                         <?php if ($staffNoUserSelected): ?>
+                                            <!-- staff must select a user first; no action shown -->
                                         <?php elseif ($accessBlocked): ?>
-                                            <div class="alert alert-warning small mb-0">
-                                                You do not have access to reserve equipment. Please contact an administrator to be assigned an Access group.
-                                            </div>
-                                            <button type="button"
-                                                    class="btn btn-sm btn-secondary w-100 mt-2"
-                                                    disabled>
-                                                Add to basket
-                                            </button>
+                                            <button type="button" class="btn card-btn-ghost btn-sm" disabled
+                                                    title="You do not have access to reserve equipment">Restricted</button>
                                         <?php elseif ($authBlocked): ?>
-                                            <div class="alert alert-warning small mb-0">
-                                                <?php if (!empty($authMissing['certs'])): ?>
-                                                    Requires certification: <?= h(implode(', ', $authMissing['certs'])) ?>
-                                                <?php else: ?>
-                                                    Requires access level: <?= h(implode(', ', $authMissing['access_levels'] ?? [])) ?>
-                                                <?php endif; ?>
-                                            </div>
-                                            <button type="button"
-                                                    class="btn btn-sm btn-secondary w-100 mt-2"
-                                                    disabled>
-                                                Add to basket
-                                            </button>
+                                            <button type="button" class="btn card-btn-ghost btn-sm" disabled
+                                                    title="<?= !empty($authMissing['certs']) ? 'Requires certification: ' . h(implode(', ', $authMissing['certs'])) : 'Requires access level: ' . h(implode(', ', $authMissing['access_levels'] ?? [])) ?>">Restricted</button>
                                         <?php elseif ($isRequestable && $freeNow > 0): ?>
-                                            <div class="row g-2 align-items-center mb-2">
-                                                <div class="col-6">
-                                                    <label class="form-label mb-0 small">Quantity</label>
-                                                    <input type="number"
-                                                           name="quantity"
-                                                           class="form-control form-control-sm"
-                                                           value="1"
-                                                           min="1"
-                                                           max="<?= $maxQty ?>">
+                                            <?php if ($maxQty > 1): ?>
+                                                <div class="btn-qty-group">
+                                                    <button type="submit" class="btn-qty-add">Add to Basket</button>
+                                                    <div class="btn-qty-sep"></div>
+                                                    <div class="btn-qty-ctrl">
+                                                        <input type="number" name="quantity" class="btn-qty-num"
+                                                               value="1" min="1" max="<?= $maxQty ?>">
+                                                        <div class="btn-qty-arrows">
+                                                            <button type="button" class="btn-qty-arr btn-qty-up" aria-label="Increase quantity"><i class="bi bi-chevron-up"></i></button>
+                                                            <button type="button" class="btn-qty-arr btn-qty-dn" aria-label="Decrease quantity"><i class="bi bi-chevron-down"></i></button>
+                                                        </div>
+                                                    </div>
                                                 </div>
-                                            </div>
-
-                                            <button type="submit"
-                                                    class="btn btn-sm btn-success w-100">
-                                                Add to basket
-                                            </button>
+                                            <?php else: ?>
+                                                <input type="hidden" name="quantity" value="1">
+                                                <button type="submit" class="btn card-btn-primary btn-sm">Add to Basket</button>
+                                            <?php endif; ?>
                                         <?php else: ?>
-                                            <div class="alert alert-danger small mb-0">
-                                                <?php if (!$isRequestable): ?>
-                                                    No requestable units available.
-                                                <?php else: ?>
-                                                    <?= $windowActive ? 'No units available for selected dates.' : 'No units available right now.' ?>
-                                                <?php endif; ?>
-                                            </div>
+                                            <button type="button" class="btn card-btn-ghost btn-sm" disabled>Unavailable</button>
                                         <?php endif; ?>
-                                    </form>
-                                </div>
+                                    </div>
+                                </form>
                             </div>
                         </div>
                     </div>
@@ -1605,7 +1557,11 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                                     $stmt->execute([':mid' => $mid, ':now' => $nowIso]);
                                     $pendingQty = (int)(($stmt->fetch(PDO::FETCH_ASSOC))['pending_qty'] ?? 0);
 
-                                    $cacheCheckedOut = $checkedOutCounts[$mid] ?? count_checked_out_assets_by_model($mid);
+                                    if (array_key_exists($mid, $checkedOutCounts)) {
+                                        $kitCacheCheckedOut = $checkedOutCounts[$mid];
+                                    } else {
+                                        $kitCacheCheckedOut = count_checked_out_assets_by_model($mid);
+                                    }
                                     $coNowStmt2 = $pdo->prepare("
                                         SELECT COUNT(*) AS co_qty
                                         FROM checkout_items ci
@@ -1616,8 +1572,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                                     ");
                                     $coNowStmt2->execute([':mid' => $mid]);
                                     $localCheckedOut = (int)(($coNowStmt2->fetch(PDO::FETCH_ASSOC))['co_qty'] ?? 0);
-                                    $activeCheckedOut = max($cacheCheckedOut, $localCheckedOut);
-                                    $booked = $pendingQty + $activeCheckedOut;
+                                    $booked = $pendingQty + max($kitCacheCheckedOut, $localCheckedOut);
                                 }
 
                                 $freeUnits = max(0, $requestableCount - $booked);
@@ -1772,22 +1727,7 @@ if (!empty($allowedCategoryMap) && !empty($categories)) {
                 <?php endif; ?>
             </button>
 
-            <hr class="cat-sidebar-section-divider">
-            <div class="cat-view-dropdown px-0">
-                <label class="form-label mb-1 fw-semibold">View</label>
-                <button type="button" class="cat-toggle-btn cat-view-toggle" id="cat-view-btn-side"
-                        aria-haspopup="true" aria-expanded="false">
-                    <i class="bi bi-list-ul" id="cat-view-icon-side" aria-hidden="true"></i>
-                    <span id="cat-view-label-side">List</span>
-                    <svg class="cat-toggle-chevron ms-auto" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                        <path d="M2 4l4 4 4-4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                </button>
-                <div class="cat-view-menu cat-dropdown" id="cat-view-menu-side" hidden>
-                    <button type="button" class="cat-view-option cat-option" data-view="list"><i class="bi bi-list-ul" aria-hidden="true"></i> List</button>
-                    <button type="button" class="cat-view-option cat-option" data-view="grid"><i class="bi bi-grid" aria-hidden="true"></i> Grid</button>
-                </div>
-            </div>
+
             <form class="filter-panel mb-4" method="get" action="catalogue.php" id="kits-filter-form">
                 <div class="filter-panel__header d-flex align-items-center gap-3">
                     <span class="filter-panel__dot"></span>
@@ -2140,8 +2080,21 @@ function closeWindowModal() {
      aria-live="polite"
      aria-hidden="true"></div>
 
+
+<!-- Quantity stepper arrows for split Add-to-Basket pill -->
+<script>
+document.addEventListener('click', function (e) {
+    const arr = e.target.closest('.btn-qty-up, .btn-qty-dn');
+    if (!arr) return;
+    const input = arr.closest('.btn-qty-ctrl').querySelector('.btn-qty-num');
+    if (!input) return;
+    const delta = arr.classList.contains('btn-qty-up') ? 1 : -1;
+    input.value = Math.min(Math.max(1, (parseInt(input.value, 10) || 1) + delta), parseInt(input.max, 10) || 1);
+});
+</script>
+
 <!-- AJAX add-to-basket + update basket count text -->
-<script src="assets/slot-picker.js"></script>
+<script src="assets/slot-picker.js<?= ($v = layout_asset_version()) !== '' ? '?v=' . $v : '' ?>"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     const loadingOverlay = document.getElementById('catalogue-loading');
@@ -2715,87 +2668,7 @@ function revertToLoggedIn(e) {
 });
 </script>
 <script>window._modelDetailIsStaff = <?= $isStaff ? 'true' : 'false' ?>;</script>
-<script>
-// ---- View toggle (grid / list) — topbar (desktop) + sidebar (mobile) ----
-(function () {
-    var storageKey = 'catalogueView';
-    var defaultView = 'list';
-    var viewMeta = {
-        list: { icon: 'bi-list-ul', label: 'List' },
-        grid: { icon: 'bi-grid',    label: 'Grid'  }
-    };
 
-    function applyView(view) {
-        var scrollArea = document.querySelector('.catalogue-scroll-area');
-        if (scrollArea) scrollArea.setAttribute('data-catalogue-view', view);
-        var meta = viewMeta[view] || viewMeta[defaultView];
-        ['top', 'side'].forEach(function (s) {
-            var icon  = document.getElementById('cat-view-icon-' + s);
-            var label = document.getElementById('cat-view-label-' + s);
-            if (icon)  icon.className = 'bi ' + meta.icon;
-            if (label) label.textContent = meta.label;
-        });
-        document.querySelectorAll('.cat-view-option').forEach(function (opt) {
-            opt.classList.toggle('active', opt.getAttribute('data-view') === view);
-        });
-    }
-
-    function closeAll() {
-        document.querySelectorAll('.cat-view-menu').forEach(function (m) {
-            m.setAttribute('hidden', '');
-        });
-        document.querySelectorAll('.cat-view-toggle').forEach(function (b) {
-            b.setAttribute('aria-expanded', 'false');
-        });
-    }
-
-    function initToggle(btnId, menuId) {
-        var btn  = document.getElementById(btnId);
-        var menu = document.getElementById(menuId);
-        if (!btn || !menu) return;
-
-        btn.addEventListener('click', function (e) {
-            e.stopPropagation();
-            if (menu.hasAttribute('hidden')) {
-                closeAll();
-                menu.removeAttribute('hidden');
-                btn.setAttribute('aria-expanded', 'true');
-            } else {
-                menu.setAttribute('hidden', '');
-                btn.setAttribute('aria-expanded', 'false');
-            }
-        });
-
-        menu.querySelectorAll('.cat-view-option').forEach(function (opt) {
-            opt.addEventListener('click', function (e) {
-                e.stopPropagation();
-                var view = opt.getAttribute('data-view');
-                try { localStorage.setItem(storageKey, view); } catch (ex) {}
-                applyView(view);
-                menu.setAttribute('hidden', '');
-                btn.setAttribute('aria-expanded', 'false');
-            });
-        });
-
-        document.addEventListener('click', function (e) {
-            if (!btn.contains(e.target) && !menu.contains(e.target)) {
-                menu.setAttribute('hidden', '');
-                btn.setAttribute('aria-expanded', 'false');
-            }
-        });
-    }
-
-    initToggle('cat-view-btn-top',    'cat-view-menu-top');
-    initToggle('cat-view-btn-side',   'cat-view-menu-side');
-    initToggle('cat-view-btn-mobile', 'cat-view-menu-mobile');
-
-    document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape') closeAll();
-    });
-
-    try { applyView(localStorage.getItem(storageKey) || defaultView); } catch (ex) { applyView(defaultView); }
-})();
-</script>
 <?php layout_footer(); ?>
 </body>
 </html>

--- a/public/delete_reservation.php
+++ b/public/delete_reservation.php
@@ -87,9 +87,14 @@ try {
 }
 
 // Redirect back with a “deleted” flag
-$redirect = $isStaff
-    ? 'staff_reservations.php?deleted=' . $resId
-    : 'my_bookings.php?deleted=' . $resId;
+$from = $_POST['from'] ?? '';
+if ($from === 'my_bookings') {
+    $redirect = 'my_bookings.php?deleted=' . $resId;
+} elseif ($isStaff) {
+    $redirect = 'staff_reservations.php?deleted=' . $resId;
+} else {
+    $redirect = 'my_bookings.php?deleted=' . $resId;
+}
 
 header('Location: ' . $redirect);
 exit;

--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,11 @@ require_once SRC_PATH . '/db.php';
 require_once SRC_PATH . '/layout.php';
 require_once SRC_PATH . '/snipeit_client.php';
 require_once SRC_PATH . '/booking_helpers.php';
+require_once SRC_PATH . '/opening_hours.php';
+
+function gantt_pct(int $mins, int $start, int $span): string {
+    return round(($mins - $start) / $span * 100, 3) . '%';
+}
 
 $config        = load_config();
 $active        = basename($_SERVER['PHP_SELF']);
@@ -52,7 +57,8 @@ if ($isStaff) {
     $tz       = new DateTimeZone($timezone);
     $utc      = new DateTimeZone('UTC');
     $now      = new DateTime('now', $tz);
-    $todayStr = $now->format('Y-m-d');
+    $todayStr    = $now->format('Y-m-d');
+    $tomorrowStr = (clone $now)->modify('+1 day')->format('Y-m-d');
 
     $todayLocalStart = new DateTime($todayStr . ' 00:00:00', $tz);
     $todayLocalEnd   = new DateTime($todayStr . ' 23:59:59', $tz);
@@ -60,28 +66,60 @@ if ($isStaff) {
     $todayUtcEnd     = (clone $todayLocalEnd)->setTimezone($utc)->format('Y-m-d H:i:s');
     $nowUtc          = (new DateTime('now', $utc))->format('Y-m-d H:i:s');
 
-    // Pending pickups today
+    // Week range for upcoming pickups/returns and the "Week at a Glance" header
+    $weekEndDay    = (clone $now)->modify('+6 days');
+    $weekEndLocal  = new DateTime($weekEndDay->format('Y-m-d') . ' 23:59:59', $tz);
+    $weekEndUtc    = (clone $weekEndLocal)->setTimezone($utc)->format('Y-m-d H:i:s');
+    $weekLabel     = $now->format('M j') . ' – ' . $weekEndDay->format('M j');
+    $weekDays      = [];
+    for ($i = 0; $i < 7; $i++) {
+        $d = (clone $now)->modify("+$i days");
+        $weekDays[] = [
+            'label'   => $d->format('D j'),
+            'isToday' => $i === 0,
+        ];
+    }
+
+    // Upcoming pickups — next 7 days
     $stmt = $pdo->prepare("
         SELECT * FROM reservations
          WHERE status IN ('pending','confirmed')
-           AND start_datetime >= :todayStart AND start_datetime <= :todayEnd
+           AND start_datetime >= :todayStart AND start_datetime <= :weekEnd
          ORDER BY start_datetime ASC
-         LIMIT 10
+         LIMIT 30
     ");
-    $stmt->execute([':todayStart' => $todayUtcStart, ':todayEnd' => $todayUtcEnd]);
-    $pendingPickups = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    $pendingCount   = count($pendingPickups);
+    $stmt->execute([':todayStart' => $todayUtcStart, ':weekEnd' => $weekEndUtc]);
+    $upcomingPickups = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    // Batch-fetch all reservation items for pending pickups (no API calls)
-    $pendingResItems = [];
-    if (!empty($pendingPickups)) {
-        $pendingResItems = batch_get_reservation_items($pdo, array_column($pendingPickups, 'id'));
+    // Today-only pickup count for stat card
+    $pendingCount = 0;
+    foreach ($upcomingPickups as $p) {
+        $dtP = new DateTime($p['start_datetime'], new DateTimeZone('UTC'));
+        $dtP->setTimezone($tz);
+        if ($dtP->format('Y-m-d') === $todayStr) $pendingCount++;
+    }
+
+    // First pickup today for stat sub-text (first scheduled, even if already past)
+    $nextPickupTime = null;
+    foreach ($upcomingPickups as $p) {
+        $dtP = new DateTime($p['start_datetime'], new DateTimeZone('UTC'));
+        $dtP->setTimezone($tz);
+        if ($dtP->format('Y-m-d') === $todayStr) {
+            $nextPickupTime = $dtP->format('H:i');
+            break;
+        }
+    }
+
+    // Fetch reservation items for upcoming pickups (for items modal)
+    $upcomingResItems = [];
+    if (!empty($upcomingPickups)) {
+        $upcomingResItems = batch_get_reservation_items($pdo, array_column($upcomingPickups, 'id'));
     }
 
     // Active checkouts count
     $activeCount = (int) $pdo->query("SELECT COUNT(*) FROM checkouts WHERE status IN ('open','partial')")->fetchColumn();
 
-    // Due today — grouped by checkout
+    // Due this week — excludes already-overdue (end_datetime > now)
     $stmt = $pdo->prepare("
         SELECT c.id AS checkout_id, c.name AS checkout_name, c.user_name, c.user_email,
                c.start_datetime, c.end_datetime, c.snipeit_user_id,
@@ -92,22 +130,35 @@ if ($isStaff) {
           LEFT JOIN reservations r ON r.id = c.reservation_id
          WHERE c.status IN ('open','partial')
            AND ci.checked_in_at IS NULL
-           AND c.end_datetime >= :todayStart AND c.end_datetime <= :todayEnd
+           AND c.end_datetime > :nowUtc AND c.end_datetime <= :weekEnd
          GROUP BY c.id
          ORDER BY c.end_datetime ASC
     ");
-    $stmt->execute([':todayStart' => $todayUtcStart, ':todayEnd' => $todayUtcEnd]);
-    $dueToday  = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    $dueCount  = count($dueToday);
+    $stmt->execute([':nowUtc' => $nowUtc, ':weekEnd' => $weekEndUtc]);
+    $dueSoon = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    // Batch-fetch checkout_items for all due-today checkouts (for items modal)
-    $dueCheckoutIds = array_column($dueToday, 'checkout_id');
+    // Today-only return count for stat card
+    $dueCount = 0;
+    $nextReturnTime = null;
+    foreach ($dueSoon as $row) {
+        $dtD = new DateTime($row['end_datetime'], new DateTimeZone('UTC'));
+        $dtD->setTimezone($tz);
+        if ($dtD->format('Y-m-d') === $todayStr) {
+            $dueCount++;
+            if ($nextReturnTime === null) {
+                $nextReturnTime = $dtD->format('H:i');
+            }
+        }
+    }
+
+    // Batch-fetch checkout_items for due-soon checkouts (for items modal)
+    $dueSoonIds = array_column($dueSoon, 'checkout_id');
     $dueCheckoutItems = [];
-    if (!empty($dueCheckoutIds)) {
-        $ph = implode(',', array_fill(0, count($dueCheckoutIds), '?'));
+    if (!empty($dueSoonIds)) {
+        $ph = implode(',', array_fill(0, count($dueSoonIds), '?'));
         $ciStmt = $pdo->prepare("SELECT checkout_id, asset_tag, asset_name, model_name, checked_in_at
                                    FROM checkout_items WHERE checkout_id IN ($ph) ORDER BY id");
-        $ciStmt->execute(array_values($dueCheckoutIds));
+        $ciStmt->execute(array_values($dueSoonIds));
         foreach ($ciStmt->fetchAll(PDO::FETCH_ASSOC) as $ci) {
             $ci['asset_name'] = html_entity_decode($ci['asset_name'] ?? '', ENT_QUOTES, 'UTF-8');
             $ci['model_name'] = html_entity_decode($ci['model_name'] ?? '', ENT_QUOTES, 'UTF-8');
@@ -115,38 +166,10 @@ if ($isStaff) {
         }
     }
 
-    // Group due-today by user_email
-    $dueTodayGrouped = [];
-    foreach ($dueToday as $row) {
-        $email = $row['user_email'];
-        if (!isset($dueTodayGrouped[$email])) {
-            $dueTodayGrouped[$email] = [
-                'user_name' => $row['user_name'],
-                'snipeit_user_id' => $row['snipeit_user_id'],
-                'checkouts' => [],
-            ];
-        }
-        $dueTodayGrouped[$email]['checkouts'][] = $row;
-    }
-
-    // Group pending pickups by user_email
-    $pickupsGrouped = [];
-    foreach ($pendingPickups as $row) {
-        $email = $row['user_email'];
-        if (!isset($pickupsGrouped[$email])) {
-            $pickupsGrouped[$email] = [
-                'user_name' => $row['user_name'],
-                'snipeit_user_id' => $row['snipeit_user_id'],
-                'reservations' => [],
-            ];
-        }
-        $pickupsGrouped[$email]['reservations'][] = $row;
-    }
-
     // Overdue — grouped by checkout
     $stmt = $pdo->prepare("
         SELECT c.id AS checkout_id, c.name AS checkout_name, c.user_name, c.user_email,
-               c.end_datetime, c.snipeit_user_id,
+               c.start_datetime, c.end_datetime, c.snipeit_user_id,
                r.name AS reservation_name, r.asset_name_cache,
                COUNT(ci.id) AS item_count
           FROM checkouts c
@@ -161,6 +184,18 @@ if ($isStaff) {
     $stmt->execute([':nowUtc' => $nowUtc]);
     $overdueItems = $stmt->fetchAll(PDO::FETCH_ASSOC);
     $overdueCount = count($overdueItems);
+
+    // Fallback: if no future returns today, check overdue items due today
+    if ($nextReturnTime === null) {
+        foreach ($overdueItems as $row) {
+            $dtD = new DateTime($row['end_datetime'], new DateTimeZone('UTC'));
+            $dtD->setTimezone($tz);
+            if ($dtD->format('Y-m-d') === $todayStr) {
+                $nextReturnTime = $dtD->format('H:i');
+                break;
+            }
+        }
+    }
 
     // Batch-fetch checkout_items for overdue checkouts (for items modal)
     $overdueCheckoutIds = array_column($overdueItems, 'checkout_id');
@@ -177,26 +212,124 @@ if ($isStaff) {
         }
     }
 
-    // Group overdue by user_email
-    $overdueGrouped = [];
-    foreach ($overdueItems as $row) {
-        $email = $row['user_email'];
-        if (!isset($overdueGrouped[$email])) {
-            $overdueGrouped[$email] = [
-                'user_name' => $row['user_name'],
-                'snipeit_user_id' => $row['snipeit_user_id'],
-                'checkouts' => [],
+    // (no static gantt_start/end_hour — open hours come from the opening_hours tables per day)
+
+    // ── Calendar-week bounds (Sun–Sat) ──────────────────────────────────
+    $ganttDayOfWeek    = (int)$now->format('w');   // 0 = Sun, 6 = Sat
+    $ganttSunday       = (clone $now)->modify("-{$ganttDayOfWeek} days");
+    $ganttSaturday     = (clone $ganttSunday)->modify('+6 days');
+    $ganttWeekStartUtc = (new DateTime($ganttSunday->format('Y-m-d')   . ' 00:00:00', $tz))
+                            ->setTimezone($utc)->format('Y-m-d H:i:s');
+    $ganttWeekEndUtc   = (new DateTime($ganttSaturday->format('Y-m-d') . ' 23:59:59', $tz))
+                            ->setTimezone($utc)->format('Y-m-d H:i:s');
+
+    $ganttWeekDays = [];
+    for ($i = 0; $i < 7; $i++) {
+        $d = (clone $ganttSunday)->modify("+{$i} days");
+        $ganttWeekDays[$i] = [
+            'date'    => $d->format('Y-m-d'),
+            'label'   => $d->format('D'),
+            'dayNum'  => $d->format('j'),
+            'isToday' => ($d->format('Y-m-d') === $todayStr),
+        ];
+    }
+
+    // ── Fetch gantt data for the full calendar week ─────────────────────
+    $stmt = $pdo->prepare("
+        SELECT id, user_name, start_datetime, status
+          FROM reservations
+         WHERE status IN ('pending','confirmed','fulfilled')
+           AND start_datetime BETWEEN :ws AND :we
+         ORDER BY start_datetime ASC
+         LIMIT 200
+    ");
+    $stmt->execute([':ws' => $ganttWeekStartUtc, ':we' => $ganttWeekEndUtc]);
+    $ganttAllPickups = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $stmt = $pdo->prepare("
+        SELECT id, user_name, end_datetime, status, snipeit_user_id
+          FROM checkouts
+         WHERE end_datetime BETWEEN :ws AND :we
+         ORDER BY end_datetime ASC
+         LIMIT 200
+    ");
+    $stmt->execute([':ws' => $ganttWeekStartUtc, ':we' => $ganttWeekEndUtc]);
+    $ganttAllReturns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    // ── Build per-day event arrays with dynamic range ───────────────────
+    $ganttNowDt   = new DateTime('now', $utc);
+    $ganttNowMins = (int)$now->format('H') * 60 + (int)$now->format('i');
+    $ganttDayData = [];
+
+    foreach ($ganttWeekDays as $i => $wd) {
+        $isToday = $wd['isToday'];
+        $pickups = [];
+        $returns = [];
+        $allMins = [];
+
+        foreach ($ganttAllPickups as $p) {
+            $dt = (new DateTime($p['start_datetime'], $utc))->setTimezone($tz);
+            if ($dt->format('Y-m-d') !== $wd['date']) continue;
+            $mins      = (int)$dt->format('H') * 60 + (int)$dt->format('i');
+            $allMins[] = $mins;
+            $pickups[] = [
+                'user'   => $p['user_name'],
+                'time'   => $dt->format('H:i'),
+                'mins'   => $mins,
+                'res_id' => (int)$p['id'],
+                'past'   => $isToday && $mins < $ganttNowMins,
+                'done'   => $p['status'] === 'fulfilled',
             ];
         }
-        $overdueGrouped[$email]['checkouts'][] = $row;
+
+        foreach ($ganttAllReturns as $r) {
+            $dt        = (new DateTime($r['end_datetime'], $utc))->setTimezone($tz);
+            if ($dt->format('Y-m-d') !== $wd['date']) continue;
+            $endDt     = new DateTime($r['end_datetime'], $utc);
+            $isOverdue = ($r['status'] !== 'closed') && ($endDt < $ganttNowDt);
+            $mins      = (int)$dt->format('H') * 60 + (int)$dt->format('i');
+            $allMins[] = $mins;
+            $returns[] = [
+                'user'        => $r['user_name'],
+                'time'        => $dt->format('H:i'),
+                'mins'        => $mins,
+                'overdue'     => $isOverdue,
+                'co_id'       => (int)$r['id'],
+                'snipeit_uid' => $r['snipeit_user_id'],
+                'past'        => $isToday && !$isOverdue && $mins < $ganttNowMins,
+                'done'        => $r['status'] === 'closed',
+            ];
+        }
+
+        // Range: always at least the facility's open hours for this day; expand if events fall outside
+        $dayHours  = oh_get_hours_for_date($wd['date']);
+        $startHour = $dayHours['is_closed'] || $dayHours['open_time']  === null ? 8  : (int)substr($dayHours['open_time'],  0, 2);
+        $endHour   = $dayHours['is_closed'] || $dayHours['close_time'] === null ? 18 : (int)substr($dayHours['close_time'], 0, 2);
+        if (!empty($allMins)) {
+            $startHour = min($startHour, max(0,  (int)floor((min($allMins) - 30) / 60)));
+            $endHour   = max($endHour,   min(23, (int)ceil( (max($allMins) + 30) / 60)));
+        }
+        $startMins = $startHour * 60;
+        $endMins   = $endHour   * 60;
+        $span      = max(60, $endMins - $startMins);
+
+        // Gridlines every 2 hrs when span > 4 hrs, otherwise every 1 hr
+        $step  = ($span > 240) ? 2 : 1;
+        $hours = [];
+        for ($h = $startHour; $h <= $endHour; $h += $step) {
+            if ($h < 12)       $lbl = "{$h}am";
+            elseif ($h === 12) $lbl = "12pm";
+            else               $lbl = ($h - 12) . "pm";
+            $hours[] = ['label' => $lbl, 'mins' => $h * 60];
+        }
+
+        $nowPctDay = ($isToday && $ganttNowMins >= $startMins && $ganttNowMins <= $endMins)
+                        ? gantt_pct($ganttNowMins, $startMins, $span) : null;
+
+        $ganttDayData[$i] = compact('pickups', 'returns', 'startMins', 'endMins', 'span', 'hours', 'nowPctDay');
     }
 }
 
-// Build lookup set of emails with overdue checkouts (for pickup card highlighting)
-$overdueUserEmails = [];
-foreach ($overdueGrouped as $email => $_grp) {
-    $overdueUserEmails[$email] = true;
-}
 $dashSubtitle = $isStaff
     ? "Staff dashboard — today's pickups, active checkouts, and items due back."
     : 'Browse bookable equipment, manage your basket, and review your bookings.';
@@ -211,211 +344,589 @@ layout_page_start([
 
         <?php if ($isStaff): ?>
 
-        <!-- Summary stat cards -->
-        <div class="row g-3 mb-3">
-            <div class="col-6 col-md-3">
-                <div class="card text-center h-100">
-                    <div class="card-body py-3">
-                        <div class="fs-3 fw-bold text-primary"><?= $pendingCount ?></div>
-                        <div class="small text-muted">Pending Pickups</div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-6 col-md-3">
-                <a href="reservations.php?tab=checkout_history" class="text-decoration-none">
-                <div class="card text-center h-100">
-                    <div class="card-body py-3">
-                        <div class="fs-3 fw-bold text-info"><?= $activeCount ?></div>
-                        <div class="small text-muted">Active Checkouts</div>
-                    </div>
-                </div>
-                </a>
-            </div>
-            <div class="col-6 col-md-3">
-                <div class="card text-center h-100">
-                    <div class="card-body py-3">
-                        <div class="fs-3 fw-bold text-warning"><?= $dueCount ?></div>
-                        <div class="small text-muted">Due Today</div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-6 col-md-3">
-                <div class="card text-center h-100">
-                    <div class="card-body py-3">
-                        <div class="fs-3 fw-bold text-danger"><?= $overdueCount ?></div>
-                        <div class="small text-muted">Overdue</div>
-                    </div>
-                </div>
-            </div>
+<style>
+/* ── Soft accent palette ─────────────────────────────────────────────
+   Scoped to .dash-scope so these colours don't leak globally.        */
+.dash-scope {
+    --dc-pickup:      #3ecf8e;
+    --dc-pickup-rgb:  62, 207, 142;
+    --dc-return:      #f5a623;
+    --dc-return-rgb:  245, 166, 35;
+    --dc-overdue:     #e05252;
+    --dc-overdue-rgb: 224, 82, 82;
+    --dc-today:       #4f8ef7;
+    --dc-today-rgb:   79, 142, 247;
+    --dc-subtle:      #444;
+}
+
+/* ── Stat cards ──────────────────────────────────────────────────────── */
+.dash-stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: .75rem;
+    margin-bottom: 1.5rem;
+}
+.dash-stat {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: .625rem;
+    padding: 1.125rem 1.25rem;
+}
+.dash-stat-label { font-size: .6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); }
+.dash-stat-value { font-size: 26px; font-weight: 700; line-height: 1.15; margin: .25rem 0 .125rem; }
+.dash-stat-sub      { font-size: .6875rem; color: var(--muted); }
+.dash-stat-sub.warn { color: var(--dc-return); }
+.dash-stat-sub.bad  { color: var(--dc-overdue); }
+
+/* ── Section header ──────────────────────────────────────────────────── */
+.dash-section-hd {
+    display: flex; align-items: center; gap: .625rem;
+    margin-bottom: .625rem;
+}
+.dash-section-dot   { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.dash-section-title { font-size: .8125rem; font-weight: 600; }
+.dash-section-pill  {
+    font-size: .6875rem; color: var(--muted);
+    background: var(--surface); border: 1px solid var(--border);
+    padding: 1px 7px; border-radius: 99px;
+}
+.dash-section-link,
+.dash-section-link:link,
+.dash-section-link:visited {
+    margin-left: auto; font-size: .6875rem;
+    color: var(--muted); text-decoration: none; transition: color .12s;
+}
+.dash-section-link:hover { color: var(--text); }
+
+/* ── Two-column layout ───────────────────────────────────────────────── */
+.dash-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.25rem;
+    margin-bottom: 1.5rem;
+    align-items: start;
+}
+
+/* ── Scrollable column box ───────────────────────────────────────────── */
+.dash-col-box {
+    border: 1px solid var(--border);
+    border-radius: .625rem;
+    display: flex;
+    flex-direction: column;
+    height: 560px;
+}
+.dash-col-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: .75rem;
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+}
+.dash-col-scroll::-webkit-scrollbar { width: 5px; }
+.dash-col-scroll::-webkit-scrollbar-track { background: transparent; }
+.dash-col-scroll::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+/* ── Individual card ─────────────────────────────────────────────────── */
+.dash-card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: .5rem;
+    padding: .875rem 1rem;
+    position: relative; overflow: hidden;
+    transition: background .12s, border-color .12s;
+    cursor: pointer;
+    display: block;
+}
+/* All link states — prevents browser visited-link purple */
+.dash-card,
+.dash-card:link,
+.dash-card:visited,
+.dash-card:hover,
+.dash-card:active {
+    color: var(--text);
+    text-decoration: none;
+}
+.dash-card:hover {
+    background: var(--surface);
+    border-color: var(--dc-subtle);
+}
+.dash-card::before {
+    content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+}
+.dash-card-pickup::before  { background: var(--dc-pickup); }
+.dash-card-return::before  { background: var(--dc-return); }
+.dash-card-overdue::before { background: var(--dc-overdue); }
+.dash-card-today::before   { background: var(--dc-today); }
+
+.dash-card-top {
+    display: flex; align-items: flex-start;
+    justify-content: space-between; gap: .5rem;
+    margin-bottom: .625rem;
+}
+/* Explicit color prevents visited-link inheritance */
+.dash-card-name { font-size: 15px; font-weight: 600; line-height: 1.3; color: var(--text); }
+.dash-card-sub  { font-size: 13px; color: var(--muted); margin-top: 2px; }
+
+/* ── Badges ──────────────────────────────────────────────────────────── */
+.dash-badge {
+    font-size: 11px; font-weight: 700; letter-spacing: .04em;
+    padding: 3px 8px; border-radius: 99px;
+    white-space: nowrap; flex-shrink: 0;
+}
+.dash-badge-today   { background: rgba(var(--dc-today-rgb), .15);   color: var(--dc-today); }
+.dash-badge-pickup  { background: rgba(var(--dc-pickup-rgb), .15);  color: var(--dc-pickup); }
+.dash-badge-return  { background: rgba(var(--dc-return-rgb), .15);  color: var(--dc-return); }
+.dash-badge-overdue { background: rgba(var(--dc-overdue-rgb), .15); color: var(--dc-overdue); }
+.dash-badge-pending { background: rgba(100,100,100,.18);            color: var(--muted); }
+
+/* ── Card meta lines ─────────────────────────────────────────────────── */
+.dash-card-info {
+    display: flex; flex-direction: column; gap: 2px;
+    margin-top: .625rem;
+}
+.dash-card-meta-line {
+    display: flex; align-items: center; gap: .3rem;
+    font-size: 13px; color: var(--muted);
+}
+.dash-card-meta-line i { opacity: .55; font-size: .8em; }
+
+/* ── Card bottom row (items + action on same line) ───────────────────── */
+.dash-card-meta-bottom {
+    display: flex; align-items: center;
+}
+.dash-card-action {
+    font-size: 12px; color: var(--muted);
+    margin-left: auto; flex-shrink: 0;
+    transition: color .12s;
+}
+.dash-card:hover .dash-card-action          { color: var(--text); }
+.dash-card-action-overdue                   { color: var(--dc-overdue); }
+.dash-card:hover .dash-card-action-overdue  { opacity: .85; }
+
+/* ── Empty state ─────────────────────────────────────────────────────── */
+.dash-empty {
+    flex: 1;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    padding: 2rem 1rem;
+    font-size: .75rem; color: var(--muted);
+}
+.dash-empty i { font-size: 1.75rem; opacity: .3; margin-bottom: .5rem; }
+
+/* ── Gantt day selector ──────────────────────────────────────────────── */
+.gantt-panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: .625rem;
+    margin-bottom: 1.5rem;
+}
+.gantt-day-selector {
+    display: flex;
+    border-bottom: 1px solid var(--border);
+    padding: .5rem .75rem 0;
+    gap: .125rem;
+}
+.gantt-day-btn {
+    flex: 1;
+    display: flex; flex-direction: column; align-items: center;
+    padding: .375rem .25rem .3rem;
+    background: none; border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: .375rem .375rem 0 0;
+    cursor: pointer; color: var(--muted);
+    transition: background .12s, color .12s;
+    margin-bottom: -1px;
+}
+.gantt-day-btn:hover  { background: var(--surface); color: var(--text); }
+.gantt-day-btn.active { color: var(--dc-today); border-bottom-color: var(--dc-today); }
+.gantt-day-name { font-size: .6rem; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; }
+.gantt-day-num  { font-size: .8125rem; font-weight: 600; line-height: 1.4; }
+
+/* ── Gantt body ──────────────────────────────────────────────────────── */
+.gantt-body  { padding: .875rem 1rem .5rem; overflow-x: auto; }
+.gantt-inner { min-width: 460px; }
+.gantt-row-wrap { display: flex; gap: .625rem; }
+.gantt-label-col {
+    width: 52px; flex-shrink: 0;
+    display: flex; flex-direction: column;
+}
+.gantt-label-cell {
+    height: 52px; display: flex; align-items: center;
+    justify-content: flex-end;
+    font-size: .675rem; text-transform: uppercase;
+    letter-spacing: .04em; color: var(--muted); padding-right: .25rem;
+}
+.gantt-tracks { flex: 1; position: relative; }
+.gantt-track  { position: relative; height: 52px; }
+.gantt-track-line {
+    position: absolute; top: 50%; left: 0; right: 0;
+    height: 2px; background: var(--border); transform: translateY(-50%);
+}
+.gantt-gridline {
+    position: absolute; top: 0; bottom: 0; width: 1px;
+    background: var(--border); opacity: .3;
+    z-index: 0; pointer-events: none;
+}
+.gantt-event {
+    position: absolute; top: 0;
+    transform: translateX(-50%);
+    display: flex; flex-direction: column; align-items: center;
+    z-index: 2; pointer-events: none;
+}
+.gantt-dot {
+    width: 10px; height: 10px; border-radius: 50%;
+    flex-shrink: 0; margin-top: 21px;
+}
+.gantt-event-label {
+    font-size: .6rem; color: var(--muted);
+    white-space: nowrap; margin-top: 3px;
+    line-height: 1.25; text-align: center;
+}
+.gantt-now-line {
+    position: absolute; top: 0; bottom: 0; width: 2px;
+    background: rgba(var(--dc-overdue-rgb), .7);
+    z-index: 3; pointer-events: none;
+}
+.gantt-axis-row    { display: flex; gap: .625rem; margin-top: .875rem; }
+.gantt-axis-spacer { width: 52px; flex-shrink: 0; }
+.gantt-axis {
+    flex: 1; position: relative; height: 1.25rem;
+    border-top: 1px solid var(--border);
+}
+.gantt-axis-tick {
+    position: absolute; transform: translateX(-50%);
+    font-size: .6rem; color: var(--muted);
+    padding-top: .2rem; white-space: nowrap;
+}
+.gantt-event-past { opacity: .3; }
+
+.gantt-legend {
+    display: flex; gap: 1rem;
+    padding: .5rem 0 .25rem calc(52px + .625rem);
+    flex-wrap: wrap;
+}
+.gantt-legend-item { display: flex; align-items: center; gap: .3rem; font-size: .675rem; color: var(--muted); }
+.gantt-legend-dot  { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.gantt-legend-line { width: 2px; height: 10px; display: inline-block; background: rgba(var(--dc-overdue-rgb), .7); }
+
+/* ── Responsive ──────────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+    .dash-stats   { grid-template-columns: repeat(2, 1fr); }
+    .dash-columns { grid-template-columns: 1fr; }
+    .dash-col-box { height: auto; max-height: 560px; }
+}
+@media (max-width: 480px) {
+    .dash-stats { grid-template-columns: repeat(2, 1fr); }
+}
+</style>
+
+<div class="dash-scope">
+
+<!-- ── Stat cards ──────────────────────────────────────────────────── -->
+<div class="dash-stats">
+    <div class="dash-stat">
+        <div class="dash-stat-label">Active Checkouts</div>
+        <div class="dash-stat-value"><?= $activeCount ?></div>
+        <div class="dash-stat-sub">&nbsp;</div>
+    </div>
+    <div class="dash-stat">
+        <div class="dash-stat-label">Pickups Today</div>
+        <div class="dash-stat-value"><?= $pendingCount ?></div>
+        <div class="dash-stat-sub"><?= $nextPickupTime ? 'Next at ' . h($nextPickupTime) : '&nbsp;' ?></div>
+    </div>
+    <div class="dash-stat">
+        <div class="dash-stat-label">Returns Today</div>
+        <div class="dash-stat-value"><?= $dueCount ?></div>
+        <div class="dash-stat-sub"><?= $nextReturnTime ? 'Next due at ' . h($nextReturnTime) : '&nbsp;' ?></div>
+    </div>
+    <div class="dash-stat">
+        <div class="dash-stat-label">Overdue</div>
+        <div class="dash-stat-value" style="color: var(--dc-overdue);"><?= $overdueCount ?></div>
+        <div class="dash-stat-sub">&nbsp;</div>
+    </div>
+</div>
+
+<!-- ── Two columns ─────────────────────────────────────────────────── -->
+<div class="dash-columns">
+
+    <!-- Pickups column -->
+    <div>
+        <div class="dash-section-hd">
+            <div class="dash-section-dot" style="background: var(--dc-pickup);"></div>
+            <div class="dash-section-title">Upcoming Pickups</div>
+            <div class="dash-section-pill"><?= count($upcomingPickups) ?></div>
+            <a href="reservations.php?tab=today" class="dash-section-link">View all →</a>
         </div>
+        <div class="dash-col-box">
+            <div class="dash-col-scroll">
+                <?php if (empty($upcomingPickups)): ?>
+                    <div class="dash-empty"><i class="bi bi-calendar2-check"></i>No upcoming pickups this week.</div>
+                <?php else: ?>
+                    <?php foreach ($upcomingPickups as $pickup):
+                        $dtStart = new DateTime($pickup['start_datetime'], new DateTimeZone('UTC'));
+                        $dtStart->setTimezone($tz);
+                        $pickupDate = $dtStart->format('Y-m-d');
 
-        <!-- Pickups and Due Today side by side -->
-        <div class="row g-3 mb-3">
-            <!-- Upcoming pickups -->
-            <div class="col-md-6">
-                <div class="card h-100">
-                    <div class="card-header fw-semibold">Upcoming Pickups Today</div>
-                    <?php if (empty($pendingPickups)): ?>
-                        <div class="card-body text-muted">No pending pickups for today.</div>
-                    <?php else: ?>
-                        <?php $qzConfig = load_config()['qz_tray'] ?? []; ?>
-                        <div class="list-group list-group-flush">
-                            <?php foreach ($pickupsGrouped as $puEmail => $puGroup): ?>
-                                <?php
-                                    $firstRes = $puGroup['reservations'][0];
-                                    $earliestTime = app_format_time($firstRes['start_datetime']);
-                                    $puIsOverdue = isset($overdueUserEmails[$puEmail]);
-                                ?>
-                                <div class="list-group-item<?= $puIsOverdue ? ' list-group-item-warning' : '' ?>">
-                                    <div class="d-flex align-items-center gap-2 mb-1">
-                                        <span class="fw-semibold" style="min-width:0; flex:1;"><?= h($puGroup['user_name']) ?></span>
-                                        <?php if ($puIsOverdue): ?>
-                                            <span class="badge bg-danger flex-shrink-0">Overdue items</span>
-                                        <?php endif; ?>
-                                        <span class="text-muted small flex-shrink-0">Pickup <?= h($earliestTime) ?></span>
-                                        <?= layout_status_badge($firstRes['status']) ?>
-                                        <a href="reservations.php?tab=today&res=<?= (int)$firstRes['id'] ?>" class="btn btn-sm btn-outline-primary flex-shrink-0">Process</a>
-                                    </div>
-                                    <?php foreach ($puGroup['reservations'] as $pickup): ?>
-                                        <?php
-                                            $resItems = $pendingResItems[(int)$pickup['id']] ?? [];
-                                            $resLabel = $pickup['name'] ?: build_items_summary_text($resItems);
-                                            $totalQty = 0;
-                                            foreach ($resItems as $ri) { $totalQty += (int)($ri['qty'] ?? 0); }
-                                        ?>
-                                        <div class="d-flex align-items-center gap-2 ps-2" style="min-width:0;">
-                                            <span class="text-muted small" style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; flex:1;">
-                                                <?= h($resLabel ?: '—') ?>
-                                            </span>
-                                            <?php if ($totalQty > 0): ?>
-                                                <a href="javascript:void(0)" onclick="showDashItems('reservation',<?= (int)$pickup['id'] ?>)"
-                                                   class="text-muted small flex-shrink-0" style="text-decoration:underline; cursor:pointer;">
-                                                    (<?= $totalQty ?> item<?= $totalQty !== 1 ? 's' : '' ?>)
-                                                </a>
-                                            <?php endif; ?>
-                                            <?php if (!empty($qzConfig['enabled'])): ?>
-                                                <button type="button" class="btn btn-sm btn-link text-muted p-0 flex-shrink-0"
-                                                        data-reservation-id="<?= (int)$pickup['id'] ?>"
-                                                        onclick="qzPrintReservationPickList(this)">
-                                                    <small>Pick List</small>
-                                                </button>
-                                            <?php endif; ?>
-                                        </div>
-                                    <?php endforeach; ?>
-                                </div>
-                            <?php endforeach; ?>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            </div>
+                        if ($pickupDate === $todayStr) {
+                            $badge = 'TODAY ' . $dtStart->format('H:i');
+                            $badgeType = 'today'; $cardType = 'today';
+                        } elseif ($pickupDate === $tomorrowStr) {
+                            $badge = 'TOMORROW'; $badgeType = 'return'; $cardType = 'return';
+                        } else {
+                            $badge = strtoupper($dtStart->format('M j'));
+                            $badgeType = 'pending'; $cardType = 'return';
+                        }
 
-            <!-- Equipment due today -->
-            <div class="col-md-6">
-                <div class="card h-100">
-                    <div class="card-header fw-semibold">Equipment Due Today</div>
-                    <?php if (empty($dueToday)): ?>
-                        <div class="card-body text-muted">No equipment due back today.</div>
-                    <?php else: ?>
-                        <div class="list-group list-group-flush">
-                            <?php foreach ($dueTodayGrouped as $dtEmail => $dtGroup): ?>
-                                <?php
-                                    $earliestDue = $dtGroup['checkouts'][0]['end_datetime'];
-                                    $dueTime = app_format_time($earliestDue);
-                                ?>
-                                <div class="list-group-item">
-                                    <div class="d-flex align-items-center gap-2 mb-1">
-                                        <span class="fw-semibold" style="min-width:0; flex:1;"><?= h($dtGroup['user_name']) ?></span>
-                                        <span class="text-muted small flex-shrink-0">Due <?= h($dueTime) ?></span>
-                                        <?php if (!empty($dtGroup['snipeit_user_id'])): ?>
-                                            <a href="quick_checkin.php?user=<?= (int)$dtGroup['snipeit_user_id'] ?>" class="btn btn-sm btn-outline-primary flex-shrink-0">Checkin</a>
-                                        <?php endif; ?>
-                                    </div>
-                                    <?php foreach ($dtGroup['checkouts'] as $coRow): ?>
-                                        <?php
-                                            $coItems = $dueCheckoutItems[(int)$coRow['checkout_id']] ?? [];
-                                            $coName = $coRow['checkout_name'] ?: ($coRow['reservation_name'] ?: ($coRow['asset_name_cache'] ?: null));
-                                            if (!$coName && !empty($coItems)) {
-                                                $names = array_column($coItems, 'asset_name');
-                                                $coName = implode(', ', array_filter($names));
-                                            }
-                                            $coLabel = $coName ?: ($coRow['item_count'] . ' item' . ($coRow['item_count'] != 1 ? 's' : ''));
-                                            $itemCount = (int)$coRow['item_count'];
-                                        ?>
-                                        <div class="d-flex align-items-center gap-2 ps-2" style="min-width:0;">
-                                            <span class="text-muted small" style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; flex:1;">
-                                                <?= h($coLabel) ?>
-                                            </span>
-                                            <?php if ($itemCount > 0): ?>
-                                                <a href="javascript:void(0)" onclick="showDashItems('checkout',<?= (int)$coRow['checkout_id'] ?>)"
-                                                   class="text-muted small flex-shrink-0" style="text-decoration:underline; cursor:pointer;">
-                                                    (<?= $itemCount ?> item<?= $itemCount !== 1 ? 's' : '' ?>)
-                                                </a>
-                                            <?php endif; ?>
-                                        </div>
-                                    <?php endforeach; ?>
-                                </div>
-                            <?php endforeach; ?>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            </div>
-        </div>
+                        $periodText = $dtStart->format('M j');
+                        if (!empty($pickup['end_datetime'])) {
+                            $dtEnd = new DateTime($pickup['end_datetime'], new DateTimeZone('UTC'));
+                            $dtEnd->setTimezone($tz);
+                            $days = max(1, (int)round(abs($dtEnd->getTimestamp() - $dtStart->getTimestamp()) / 86400));
+                            $periodText = $dtStart->format('M j') . ' – ' . $dtEnd->format('M j')
+                                . ' (' . $days . ' day' . ($days !== 1 ? 's' : '') . ')';
+                        }
 
-        <!-- v2: Overdue full-width -->
-        <div class="card mb-3 <?= $overdueCount > 0 ? 'border-danger' : '' ?>">
-            <div class="card-header fw-semibold <?= $overdueCount > 0 ? 'bg-danger text-white' : '' ?>">
-                Overdue Items
-            </div>
-            <?php if (empty($overdueItems)): ?>
-                <div class="card-body text-muted">No overdue items.</div>
-            <?php else: ?>
-                <div class="list-group list-group-flush">
-                    <?php foreach ($overdueGrouped as $odEmail => $odGroup): ?>
-                        <?php
-                            $earliestOverdue = $odGroup['checkouts'][0]['end_datetime'];
-                            $overdueTime = app_format_datetime($earliestOverdue);
-                        ?>
-                        <div class="list-group-item">
-                            <div class="d-flex align-items-center gap-2 mb-1">
-                                <span class="fw-semibold" style="min-width:0; flex:1;"><?= h($odGroup['user_name']) ?></span>
-                                <span class="text-muted small flex-shrink-0">Due <?= h($overdueTime) ?></span>
-                                <?php if (!empty($odGroup['snipeit_user_id'])): ?>
-                                    <a href="quick_checkin.php?user=<?= (int)$odGroup['snipeit_user_id'] ?>" class="btn btn-sm btn-outline-danger flex-shrink-0">Checkin</a>
-                                <?php endif; ?>
+                        $resItems = $upcomingResItems[(int)$pickup['id']] ?? [];
+                        $totalQty = array_sum(array_column($resItems, 'qty'));
+                        $subtitle = $pickup['name'] ?: build_items_summary_text($resItems);
+                    ?>
+                    <a href="reservations.php?tab=today&res=<?= (int)$pickup['id'] ?>"
+                       class="dash-card dash-card-<?= h($cardType) ?>">
+                        <div class="dash-card-top">
+                            <div>
+                                <div class="dash-card-name"><?= h($pickup['user_name']) ?></div>
+                                <div class="dash-card-sub"><?= h($subtitle ?: '—') ?></div>
                             </div>
-                            <?php foreach ($odGroup['checkouts'] as $coRow): ?>
-                                <?php
-                                    $coItems = $overdueCheckoutItems[(int)$coRow['checkout_id']] ?? [];
-                                    $coName = $coRow['checkout_name'] ?: ($coRow['reservation_name'] ?: ($coRow['asset_name_cache'] ?: null));
-                                    if (!$coName && !empty($coItems)) {
-                                        $names = array_column($coItems, 'asset_name');
-                                        $coName = implode(', ', array_filter($names));
-                                    }
-                                    $coLabel = $coName ?: ($coRow['item_count'] . ' item' . ($coRow['item_count'] != 1 ? 's' : ''));
-                                    $itemCount = (int)$coRow['item_count'];
-                                ?>
-                                <div class="d-flex align-items-center gap-2 ps-2" style="min-width:0;">
-                                    <span class="text-muted small" style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; flex:1;">
-                                        <?= h($coLabel) ?>
-                                    </span>
-                                    <?php if ($itemCount > 0): ?>
-                                        <a href="javascript:void(0)" onclick="showDashItems('overdue',<?= (int)$coRow['checkout_id'] ?>)"
-                                           class="text-muted small flex-shrink-0" style="text-decoration:underline; cursor:pointer;">
-                                            (<?= $itemCount ?> item<?= $itemCount !== 1 ? 's' : '' ?>)
-                                        </a>
-                                    <?php endif; ?>
+                            <span class="dash-badge dash-badge-<?= h($badgeType) ?>"><?= h($badge) ?></span>
+                        </div>
+                        <div class="dash-card-info">
+                            <div class="dash-card-meta-line"><i class="bi bi-calendar3"></i> <?= h($periodText) ?></div>
+                            <div class="dash-card-meta-bottom">
+                                <?php if ($totalQty > 0): ?><span class="dash-card-meta-line"><i class="bi bi-box-seam"></i> <?= $totalQty ?> item<?= $totalQty !== 1 ? 's' : '' ?></span><?php endif; ?>
+                                <span class="dash-card-action">Process →</span>
+                            </div>
+                        </div>
+                    </a>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <!-- Returns column -->
+    <div>
+        <div class="dash-section-hd">
+            <div class="dash-section-dot" style="background: var(--dc-return);"></div>
+            <div class="dash-section-title">Upcoming Returns</div>
+            <div class="dash-section-pill"><?= count($dueSoon) + count($overdueItems) ?></div>
+            <a href="reservations.php?tab=checkout_history" class="dash-section-link">View all →</a>
+        </div>
+        <div class="dash-col-box">
+            <div class="dash-col-scroll">
+                <?php if (empty($dueSoon) && empty($overdueItems)): ?>
+                    <div class="dash-empty"><i class="bi bi-check2-all"></i>No returns due this week.</div>
+                <?php else: ?>
+
+                    <?php foreach ($dueSoon as $row):
+                        $dtEnd = new DateTime($row['end_datetime'], new DateTimeZone('UTC'));
+                        $dtEnd->setTimezone($tz);
+                        $returnDate = $dtEnd->format('Y-m-d');
+
+                        if ($returnDate === $todayStr) {
+                            $badge = 'TODAY ' . $dtEnd->format('H:i');
+                            $badgeType = 'today'; $cardType = 'today';
+                        } elseif ($returnDate === $tomorrowStr) {
+                            $badge = 'TOMORROW'; $badgeType = 'return'; $cardType = 'return';
+                        } else {
+                            $badge = strtoupper($dtEnd->format('M j'));
+                            $badgeType = 'pending'; $cardType = 'return';
+                        }
+
+                        $coName = $row['checkout_name'] ?: ($row['reservation_name'] ?: ($row['asset_name_cache'] ?: null));
+                        if (!$coName) {
+                            $coItems = $dueCheckoutItems[(int)$row['checkout_id']] ?? [];
+                            if (!empty($coItems)) {
+                                $coName = implode(', ', array_filter(array_column($coItems, 'asset_name')));
+                            }
+                        }
+                        $subtitle  = $coName ?: null;
+                        $itemCount = (int)$row['item_count'];
+                        $dtRStart  = (new DateTime($row['start_datetime'], new DateTimeZone('UTC')))->setTimezone($tz);
+                        $dtREnd    = (new DateTime($row['end_datetime'],   new DateTimeZone('UTC')))->setTimezone($tz);
+                        $rDays     = max(1, (int)round(abs($dtREnd->getTimestamp() - $dtRStart->getTimestamp()) / 86400));
+                        $periodText = $dtRStart->format('M j') . ' – ' . $dtREnd->format('M j')
+                            . ' (' . $rDays . ' day' . ($rDays !== 1 ? 's' : '') . ')';
+
+                        $linkUrl = !empty($row['snipeit_user_id'])
+                            ? 'quick_checkin.php?user=' . (int)$row['snipeit_user_id']
+                            : 'reservations.php?tab=checkout_history';
+                    ?>
+                    <a href="<?= h($linkUrl) ?>" class="dash-card dash-card-<?= h($cardType) ?>">
+                        <div class="dash-card-top">
+                            <div>
+                                <div class="dash-card-name"><?= h($row['user_name']) ?></div>
+                                <div class="dash-card-sub"><?= h($subtitle ?: '—') ?></div>
+                            </div>
+                            <span class="dash-badge dash-badge-<?= h($badgeType) ?>"><?= h($badge) ?></span>
+                        </div>
+                        <div class="dash-card-info">
+                            <div class="dash-card-meta-line"><i class="bi bi-calendar3"></i> <?= h($periodText) ?></div>
+                            <div class="dash-card-meta-bottom">
+                                <?php if ($itemCount > 0): ?><span class="dash-card-meta-line"><i class="bi bi-box-seam"></i> <?= $itemCount ?> item<?= $itemCount !== 1 ? 's' : '' ?></span><?php endif; ?>
+                                <span class="dash-card-action">Check In →</span>
+                            </div>
+                        </div>
+                    </a>
+                    <?php endforeach; ?>
+
+                    <?php foreach ($overdueItems as $row):
+                        $dtEnd = new DateTime($row['end_datetime'], new DateTimeZone('UTC'));
+                        $dtEnd->setTimezone($tz);
+                        $nowLocal  = new DateTime('now', $tz);
+                        $daysLate  = max(0, (int)floor(($nowLocal->getTimestamp() - $dtEnd->getTimestamp()) / 86400));
+                        $badge     = $daysLate >= 1
+                            ? $daysLate . ' DAY' . ($daysLate !== 1 ? 'S' : '') . ' LATE'
+                            : 'DUE ' . $dtEnd->format('H:i');
+
+                        $coName = $row['checkout_name'] ?: ($row['reservation_name'] ?: ($row['asset_name_cache'] ?: null));
+                        if (!$coName) {
+                            $coItems = $overdueCheckoutItems[(int)$row['checkout_id']] ?? [];
+                            if (!empty($coItems)) {
+                                $coName = implode(', ', array_filter(array_column($coItems, 'asset_name')));
+                            }
+                        }
+                        $subtitle  = $coName ?: null;
+                        $itemCount = (int)$row['item_count'];
+                        $dtOStart  = (new DateTime($row['start_datetime'], new DateTimeZone('UTC')))->setTimezone($tz);
+                        $dtOEnd    = (new DateTime($row['end_datetime'],   new DateTimeZone('UTC')))->setTimezone($tz);
+                        $oDays     = max(1, (int)round(abs($dtOEnd->getTimestamp() - $dtOStart->getTimestamp()) / 86400));
+                        $periodText = $dtOStart->format('M j') . ' – ' . $dtOEnd->format('M j')
+                            . ' (' . $oDays . ' day' . ($oDays !== 1 ? 's' : '') . ')';
+
+                        $linkUrl = !empty($row['snipeit_user_id'])
+                            ? 'quick_checkin.php?user=' . (int)$row['snipeit_user_id']
+                            : 'reservations.php?tab=checkout_history';
+                    ?>
+                    <a href="<?= h($linkUrl) ?>" class="dash-card dash-card-overdue">
+                        <div class="dash-card-top">
+                            <div>
+                                <div class="dash-card-name"><?= h($row['user_name']) ?></div>
+                                <div class="dash-card-sub"><?= h($subtitle ?: '—') ?></div>
+                            </div>
+                            <span class="dash-badge dash-badge-overdue"><?= h($badge) ?></span>
+                        </div>
+                        <div class="dash-card-info">
+                            <div class="dash-card-meta-line"><i class="bi bi-calendar3"></i> <?= h($periodText) ?></div>
+                            <div class="dash-card-meta-bottom">
+                                <?php if ($itemCount > 0): ?><span class="dash-card-meta-line"><i class="bi bi-box-seam"></i> <?= $itemCount ?> item<?= $itemCount !== 1 ? 's' : '' ?></span><?php endif; ?>
+                                <span class="dash-card-action dash-card-action-overdue">Check In →</span>
+                            </div>
+                        </div>
+                    </a>
+                    <?php endforeach; ?>
+
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+</div><!-- /.dash-columns -->
+
+<!-- ── Schedule ──────────────────────────────────────────────────────── -->
+<div class="dash-section-hd">
+    <div class="dash-section-dot" style="background: var(--dc-today);"></div>
+    <div class="dash-section-title">Schedule</div>
+</div>
+
+<div class="gantt-panel">
+
+    <!-- Day selector -->
+    <div class="gantt-day-selector">
+        <?php foreach ($ganttWeekDays as $i => $wd): ?>
+            <button class="gantt-day-btn<?= $wd['isToday'] ? ' active' : '' ?>" data-day="<?= $i ?>">
+                <span class="gantt-day-name"><?= h($wd['label']) ?></span>
+                <span class="gantt-day-num"><?= h($wd['dayNum']) ?></span>
+            </button>
+        <?php endforeach; ?>
+    </div>
+
+    <!-- One panel per day -->
+    <?php foreach ($ganttWeekDays as $i => $wd):
+        $gd      = $ganttDayData[$i];
+        $isToday = $wd['isToday'];
+    ?>
+    <div class="gantt-day-panel" data-day="<?= $i ?>"<?= $isToday ? '' : ' style="display:none"' ?>>
+        <div class="gantt-body">
+            <div class="gantt-inner">
+                <div class="gantt-row-wrap">
+                    <div class="gantt-label-col">
+                        <div class="gantt-label-cell">Pickups</div>
+                        <div class="gantt-label-cell">Returns</div>
+                    </div>
+                    <div class="gantt-tracks">
+                        <?php foreach ($gd['hours'] as $gh): ?>
+                            <div class="gantt-gridline" style="left:<?= gantt_pct($gh['mins'], $gd['startMins'], $gd['span']) ?>;"></div>
+                        <?php endforeach; ?>
+
+                        <!-- Pickup track -->
+                        <div class="gantt-track">
+                            <div class="gantt-track-line"></div>
+                            <?php foreach ($gd['pickups'] as $p):
+                                $pct   = gantt_pct($p['mins'], $gd['startMins'], $gd['span']);
+                                $first = explode(' ', $p['user'])[0];
+                            ?>
+                                <div class="gantt-event<?= ($p['past'] || $p['done']) ? ' gantt-event-past' : '' ?>" style="left:<?= $pct ?>;" title="<?= h($p['user']) ?>">
+                                    <div class="gantt-dot" style="background:var(--dc-pickup);"></div>
+                                    <div class="gantt-event-label"><?= h($first) ?><br><?= h($p['time']) ?></div>
                                 </div>
                             <?php endforeach; ?>
                         </div>
-                    <?php endforeach; ?>
+
+                        <!-- Return track -->
+                        <div class="gantt-track">
+                            <div class="gantt-track-line"></div>
+                            <?php foreach ($gd['returns'] as $r):
+                                $pct      = gantt_pct($r['mins'], $gd['startMins'], $gd['span']);
+                                $dotColor = $r['overdue'] ? 'var(--dc-overdue)' : 'var(--dc-return)';
+                                $first    = explode(' ', $r['user'])[0];
+                            ?>
+                                <div class="gantt-event<?= ($r['past'] || $r['done']) ? ' gantt-event-past' : '' ?>" style="left:<?= $pct ?>;" title="<?= h($r['user']) ?>">
+                                    <div class="gantt-dot" style="background:<?= $dotColor ?>;"></div>
+                                    <div class="gantt-event-label"><?= h($first) ?><br><?= h($r['time']) ?></div>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+
+                        <?php if ($gd['nowPctDay'] !== null): ?>
+                            <div class="gantt-now-line" style="left:<?= $gd['nowPctDay'] ?>;"></div>
+                        <?php endif; ?>
+                    </div>
                 </div>
-            <?php endif; ?>
-            <?php if ($overdueCount > 0): ?>
-                <div class="card-footer text-center">
-                    <a href="overdue_report.php" class="btn btn-sm btn-outline-danger">View Full Report</a>
+
+                <div class="gantt-axis-row">
+                    <div class="gantt-axis-spacer"></div>
+                    <div class="gantt-axis">
+                        <?php foreach ($gd['hours'] as $gh): ?>
+                            <span class="gantt-axis-tick" style="left:<?= gantt_pct($gh['mins'], $gd['startMins'], $gd['span']) ?>;"><?= h($gh['label']) ?></span>
+                        <?php endforeach; ?>
+                    </div>
                 </div>
-            <?php endif; ?>
+
+                <div class="gantt-legend">
+                    <span class="gantt-legend-item"><span class="gantt-legend-dot" style="background:var(--dc-pickup);"></span> Pickup</span>
+                    <span class="gantt-legend-item"><span class="gantt-legend-dot" style="background:var(--dc-return);"></span> Return due</span>
+                    <span class="gantt-legend-item"><span class="gantt-legend-dot" style="background:var(--dc-overdue);"></span> Overdue</span>
+                    <?php if ($gd['nowPctDay'] !== null): ?><span class="gantt-legend-item"><span class="gantt-legend-line"></span> Now</span><?php endif; ?>
+                </div>
+            </div>
         </div>
+    </div>
+    <?php endforeach; ?>
+
+</div><!-- /.gantt-panel -->
+
+</div><!-- /.dash-scope -->
 
         <!-- Items detail modal -->
         <div id="dashItemsBackdrop" style="display:none; position:fixed; inset:0; background:var(--backdrop-modal); z-index:1050;" onclick="closeDashItemsModal()"></div>
@@ -430,9 +941,9 @@ layout_page_start([
         </div>
 
 <script>
-var dashCheckoutItems = <?= json_encode($dueCheckoutItems, JSON_HEX_TAG) ?>;
-var dashOverdueItems = <?= json_encode($overdueCheckoutItems, JSON_HEX_TAG) ?>;
-var dashReservationItems = <?= json_encode($pendingResItems, JSON_HEX_TAG) ?>;
+var dashCheckoutItems    = <?= json_encode($dueCheckoutItems,    JSON_HEX_TAG) ?>;
+var dashOverdueItems     = <?= json_encode($overdueCheckoutItems, JSON_HEX_TAG) ?>;
+var dashReservationItems = <?= json_encode($upcomingResItems,    JSON_HEX_TAG) ?>;
 
 function escHtml(s) {
     var d = document.createElement('div');
@@ -442,7 +953,7 @@ function escHtml(s) {
 
 function showDashItems(type, id) {
     var title = document.getElementById('dashItemsTitle');
-    var body = document.getElementById('dashItemsBody');
+    var body  = document.getElementById('dashItemsBody');
     var items, html;
 
     if (type === 'checkout' || type === 'overdue') {
@@ -470,12 +981,12 @@ function showDashItems(type, id) {
 
     body.innerHTML = html;
     document.getElementById('dashItemsBackdrop').style.display = 'block';
-    document.getElementById('dashItemsModal').style.display = 'block';
+    document.getElementById('dashItemsModal').style.display    = 'block';
 }
 
 function closeDashItemsModal() {
     document.getElementById('dashItemsBackdrop').style.display = 'none';
-    document.getElementById('dashItemsModal').style.display = 'none';
+    document.getElementById('dashItemsModal').style.display    = 'none';
 }
 
 document.addEventListener('keydown', function(e) {
@@ -483,6 +994,21 @@ document.addEventListener('keydown', function(e) {
         closeDashItemsModal();
     }
 });
+
+// ── Gantt day selector ────────────────────────────────────────────────
+(function() {
+    var btns   = document.querySelectorAll('.gantt-day-btn');
+    var panels = document.querySelectorAll('.gantt-day-panel');
+    btns.forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            btns.forEach(function(b)   { b.classList.remove('active'); });
+            panels.forEach(function(p) { p.style.display = 'none'; });
+            this.classList.add('active');
+            var panel = document.querySelector('.gantt-day-panel[data-day="' + this.dataset.day + '"]');
+            if (panel) panel.style.display = 'block';
+        });
+    });
+})();
 </script>
 
         <?php else: ?>

--- a/public/my_bookings.php
+++ b/public/my_bookings.php
@@ -307,6 +307,7 @@ layout_page_start([
                                                       action="delete_reservation.php"
                                                       onsubmit="return confirm('Delete reservation #<?= $resId ?>?\n\nThis will permanently remove the reservation and all its items. This cannot be undone.');">
                                                     <input type="hidden" name="reservation_id" value="<?= $resId ?>">
+                                                    <input type="hidden" name="from" value="my_bookings">
                                                     <button type="submit" class="btn btn-outline-danger btn-sm">
                                                         Delete reservation
                                                     </button>
@@ -409,6 +410,7 @@ layout_page_start([
                                                           action="delete_reservation.php"
                                                           onsubmit="return confirm('Delete reservation #<?= $resId ?>?\n\nThis will permanently remove the reservation and all its items. This cannot be undone.');">
                                                         <input type="hidden" name="reservation_id" value="<?= $resId ?>">
+                                                        <input type="hidden" name="from" value="my_bookings">
                                                         <button type="submit" class="btn btn-outline-danger btn-sm">
                                                             Delete reservation
                                                         </button>

--- a/public/settings.php
+++ b/public/settings.php
@@ -46,6 +46,15 @@ try {
     $categoryFetchError = $e->getMessage();
 }
 
+$manufacturerOptions    = [];
+$manufacturerFetchError = '';
+try {
+    $manufacturerOptions = get_bookable_manufacturers();
+} catch (Throwable $e) {
+    $manufacturerOptions    = [];
+    $manufacturerFetchError = $e->getMessage();
+}
+
 $snipeitGroups      = [];
 $groupsFetchError   = '';
 try {
@@ -390,6 +399,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $app['quick_checkout_enabled'] = isset($_POST['app_quick_checkout_enabled']);
     $app['slot_interval_minutes'] = max(5, min(60, (int)$post('app_slot_interval', $app['slot_interval_minutes'] ?? 15)));
     $app['slot_capacity'] = max(0, (int)$post('app_slot_capacity', $app['slot_capacity'] ?? 0));
+
+    $suppressRaw = $_POST['suppress_manufacturers'] ?? [];
+    $app['suppress_manufacturers'] = is_array($suppressRaw)
+        ? array_values(array_filter(array_map('trim', $suppressRaw), fn($v) => $v !== ''))
+        : [];
 
     $catalogue = $config['catalogue'] ?? [];
     $allowedRaw = $_POST['catalogue_allowed_categories'] ?? [];
@@ -766,6 +780,11 @@ if (!is_array($allowedCategoryIds)) {
     $allowedCategoryIds = [];
 }
 $allowedCategoryIds = array_map('intval', $allowedCategoryIds);
+
+$suppressedManuNames = $cfg(['app', 'suppress_manufacturers'], []);
+if (!is_array($suppressedManuNames)) {
+    $suppressedManuNames = [];
+}
 
 layout_page_start([
     'active'             => $active,
@@ -1381,6 +1400,41 @@ layout_page_start([
                                 <?php endforeach; ?>
                             </div>
                             <div class="form-text mt-2">Tip: leave all unchecked to allow every category to show in the dropdown.</div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title mb-1">Suppressed manufacturers</h5>
+                        <p class="text-muted small mb-3">Choose which manufacturer names are hidden from catalogue cards. Checked manufacturers will not have their name shown. Only manufacturers with at least one requestable model appear here.</p>
+                        <?php if ($manufacturerFetchError): ?>
+                            <div class="alert alert-warning small mb-3">
+                                Could not load manufacturers from Snipe-IT: <?= h($manufacturerFetchError) ?>
+                            </div>
+                        <?php elseif (empty($manufacturerOptions)): ?>
+                            <div class="text-muted small">No manufacturers found (no requestable models).</div>
+                        <?php else: ?>
+                            <div class="row g-2">
+                                <?php foreach ($manufacturerOptions as $mname): ?>
+                                    <div class="col-md-3 col-sm-4 col-6">
+                                        <div class="form-check">
+                                            <input class="form-check-input"
+                                                   type="checkbox"
+                                                   name="suppress_manufacturers[]"
+                                                   id="manu_suppress_<?= h(preg_replace('/[^a-z0-9]/i', '_', $mname)) ?>"
+                                                   value="<?= h($mname) ?>"
+                                                <?= in_array($mname, $suppressedManuNames, true) ? 'checked' : '' ?>>
+                                            <label class="form-check-label" for="manu_suppress_<?= h(preg_replace('/[^a-z0-9]/i', '_', $mname)) ?>">
+                                                <?= h($mname) ?>
+                                            </label>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                            <div class="form-text mt-2">Tip: leave all unchecked to show the manufacturer on every card.</div>
                         <?php endif; ?>
                     </div>
                 </div>

--- a/src/layout.php
+++ b/src/layout.php
@@ -89,14 +89,43 @@ if (!function_exists('layout_adjust_lightness')) {
     }
 }
 
+if (!function_exists('layout_asset_version')) {
+    /**
+     * Returns the current git commit hash (7 chars) used as a cache-busting query param.
+     * Returns '' when the git HEAD file can't be read.
+     */
+    function layout_asset_version(): string
+    {
+        static $hash = null;
+        if ($hash !== null) {
+            return $hash;
+        }
+        $hash = '';
+        $headFile = APP_ROOT . '/.git/HEAD';
+        if (is_file($headFile)) {
+            $head = trim((string)@file_get_contents($headFile));
+            if (str_starts_with($head, 'ref: ')) {
+                $refPath = APP_ROOT . '/.git/' . substr($head, 5);
+                if (is_file($refPath)) {
+                    $hash = substr(trim((string)@file_get_contents($refPath)), 0, 7);
+                }
+            } else {
+                $hash = substr($head, 0, 7);
+            }
+        }
+        return $hash;
+    }
+}
+
 if (!function_exists('layout_stylesheet_url')) {
     /**
-     * Return the stylesheet URL.
+     * Return the stylesheet URL with a cache-busting version param.
      * Usage in page templates: <link rel="stylesheet" href="<?= layout_stylesheet_url() ?>">
      */
     function layout_stylesheet_url(?array $cfg = null): string
     {
-        return 'assets/style.css';
+        $v = layout_asset_version();
+        return 'assets/style.css' . ($v !== '' ? '?v=' . $v : '');
     }
 }
 
@@ -154,7 +183,8 @@ if (!function_exists('layout_render_nav')) {
         $currentTab   = $_GET['tab'] ?? 'kits';
 
         $links = [
-            ['href' => 'index.php',       'label' => 'Dashboard', 'staff' => false, 'icon' => 'bi-speedometer2'],
+            ['type' => 'header', 'label' => 'Overview',    'staff' => false],
+            ['href' => 'index.php',       'label' => 'Dashboard', 'staff' => false, 'icon' => 'bi-grid-fill'],
             ['href' => 'my_bookings.php', 'label' => 'My Gear',   'staff' => false, 'icon' => 'bi-calendar-check'],
             ['href' => 'reservations.php',            'label' => 'Reservations',      'staff' => true,  'icon' => 'bi-calendar3'],
 
@@ -172,7 +202,7 @@ if (!function_exists('layout_render_nav')) {
 
         $html = '<nav id="app-nav" class="app-nav" aria-label="Main navigation">'
               . '<button class="app-nav-hamburger" type="button" aria-label="Expand navigation" aria-expanded="false" aria-controls="app-nav"><i class="bi bi-list" aria-hidden="true"></i></button>'
-              . '<a href="index.php" class="app-nav-brand">Wrap It</a>';
+              . '<a href="index.php" class="app-nav-brand">Wrap It<span class="app-nav-alpha-tag">Alpha</span></a>';
         foreach ($links as $link) {
             if (isset($link['enabled']) && !$link['enabled']) {
                 continue;
@@ -283,19 +313,7 @@ if (!function_exists('layout_render_topbar')) {
             $html .= '<span class="app-topbar-subtitle" id="app-topbar-crumb-1">' . htmlspecialchars($subtitle, ENT_QUOTES, 'UTF-8') . '</span>';
         }
         $html .= '</span>';
-        if ($active === 'catalogue.php') {
-            $html .= '<div class="cat-topbar-view">';
-            $html .= '<button type="button" class="cat-topbar-view-btn cat-view-toggle" id="cat-view-btn-top" aria-haspopup="true" aria-expanded="false">';
-            $html .= '<i class="bi bi-list-ul" id="cat-view-icon-top" aria-hidden="true"></i>';
-            $html .= '<span id="cat-view-label-top">List</span>';
-            $html .= '<svg class="cat-toggle-chevron ms-1" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 4l4 4 4-4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-            $html .= '</button>';
-            $html .= '<div class="cat-view-menu" id="cat-view-menu-top" hidden>';
-            $html .= '<button type="button" class="cat-view-option" data-view="list"><i class="bi bi-list-ul" aria-hidden="true"></i> List</button>';
-            $html .= '<button type="button" class="cat-view-option" data-view="grid"><i class="bi bi-grid" aria-hidden="true"></i> Grid</button>';
-            $html .= '</div>';
-            $html .= '</div>';
-        }
+
         if ($active === 'catalogue.php') {
             $html .= '<a href="basket.php" class="app-topbar-basket"><i class="bi bi-basket" aria-hidden="true"></i> View Basket</a>';
         }
@@ -413,30 +431,19 @@ if (!function_exists('layout_footer')) {
         $version     = $versionRaw !== '' ? $versionRaw : 'dev';
         $versionEsc  = htmlspecialchars($version, ENT_QUOTES, 'UTF-8');
 
-        $commitHash = '';
-        $headFile = APP_ROOT . '/.git/HEAD';
-        if (is_file($headFile)) {
-            $head = trim((string)@file_get_contents($headFile));
-            if (str_starts_with($head, 'ref: ')) {
-                $refPath = APP_ROOT . '/.git/' . substr($head, 5);
-                if (is_file($refPath)) {
-                    $commitHash = substr(trim((string)@file_get_contents($refPath)), 0, 7);
-                }
-            } else {
-                $commitHash = substr($head, 0, 7);
-            }
-        }
+        $commitHash   = layout_asset_version();
+        $vSuffix      = $commitHash !== '' ? '?v=' . $commitHash : '';
         $commitSuffix = $commitHash !== '' ? ' (' . $commitHash . ')' : '';
 
-        echo '<script src="assets/nav.js"></script>';
+        echo '<script src="assets/nav.js' . $vSuffix . '"></script>';
         echo '<script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"></script>';
-        echo '<script src="assets/datetime-picker.js"></script>';
+        echo '<script src="assets/datetime-picker.js' . $vSuffix . '"></script>';
 
         // QZ Tray receipt printing (staff only)
         $qzConfig = load_config()['qz_tray'] ?? [];
         if (!empty($qzConfig['enabled']) && (!empty($_SESSION['user']['is_staff']) || !empty($_SESSION['user']['is_admin']))) {
             echo '<script src="https://cdn.jsdelivr.net/npm/qz-tray@2/qz-tray.js"></script>';
-            echo '<script src="assets/qz-print.js"></script>';
+            echo '<script src="assets/qz-print.js' . $vSuffix . '"></script>';
             echo '<script>SnipePrint.init(' . json_encode([
                 'connectionType' => $qzConfig['connection_type'] ?? 'usb',
                 'printerName'    => $qzConfig['printer_name'] ?? '',

--- a/src/snipeit_client.php
+++ b/src/snipeit_client.php
@@ -337,6 +337,41 @@ function get_model_categories(): array
 }
 
 /**
+ * Return sorted unique manufacturer names across all requestable models.
+ */
+function get_bookable_manufacturers(): array
+{
+    $manufacturers = [];
+    $offset = 0;
+    $limit  = 500;
+
+    while (true) {
+        $data = snipeit_request('GET', 'models', [
+            'requestable' => 'true',
+            'limit'       => $limit,
+            'offset'      => $offset,
+        ]);
+        $rows = $data['rows'] ?? [];
+        if (!is_array($rows) || empty($rows)) {
+            break;
+        }
+        foreach ($rows as $model) {
+            $name = trim($model['manufacturer']['name'] ?? '');
+            if ($name !== '') {
+                $manufacturers[$name] = true;
+            }
+        }
+        if (count($rows) < $limit) {
+            break;
+        }
+        $offset += $limit;
+    }
+
+    ksort($manufacturers);
+    return array_keys($manufacturers);
+}
+
+/**
  * Fetch a single model by ID.
  *
  * @param int $modelId


### PR DESCRIPTION
## Summary

- **Catalogue card v2** — redesigned grid-view model cards using new `model-card-v2` CSS class with image area, meta row, specs, and footer sections; removes ~139 lines of old card markup
- **Manufacturer suppression** — new `suppress_manufacturers` config key (array of name strings); settings UI with checkboxes to hide specific manufacturers from catalogue cards; new `get_bookable_manufacturers()` API function in `snipeit_client.php`
- **Dashboard "Week at a Glance"** — expands pickups and returns panels from today-only to a 7-day window; adds Gantt timeline for today's hourly schedule; stat cards now show count for today with weekly context
- **Delete reservation redirect fix** — `delete_reservation.php` now reads a `from` POST param; `my_bookings.php` passes `from=my_bookings` so deletes from that page redirect back correctly instead of going to staff reservations
- **Nav alpha tag** — "Alpha" badge added below brand text in sidebar via `.app-nav-alpha-tag`; CSS variable additions (`--status-success-rgb`) and nav link padding/hover state refinements

## Test plan

- [ ] Grid-view catalogue cards render correctly with new v2 layout
- [ ] Manufacturer suppression: add a manufacturer name in Settings → confirm cards for that manufacturer are hidden in catalogue
- [ ] Dashboard shows pickups and returns for next 7 days (not just today); Gantt timeline renders for today's slots
- [ ] Delete a reservation from My Bookings → confirm redirect lands back on My Bookings (not staff page)
- [ ] Nav sidebar shows "Alpha" tag below the brand name
- [ ] `config.example.php` reflects new `suppress_manufacturers` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)