### PR TITLE
Self-heal stale model_files cache on 404

### DIFF
--- a/public/v_file.php
+++ b/public/v_file.php
@@ -7,6 +7,10 @@
 // Access control: file_id must actually belong to model_id. Same threat
 // model as v.php — anyone with a valid QR/tag can already reach this; we
 // only block accidental cross-model access via the proxy.
+//
+// Self-healing: if the file is missing in the cached file list (cache is
+// stale) or Snipe-IT returns 404 (file deleted upstream), we bust the
+// model_files cache so the next v.php load fetches fresh data.
 
 require_once __DIR__ . '/../src/bootstrap.php';
 require_once SRC_PATH . '/snipeit_client.php';
@@ -20,8 +24,44 @@ if ($modelId <= 0 || $fileId <= 0) {
     exit;
 }
 
-// Verify the file is actually attached to this model. Avoids using the
-// proxy as a general-purpose "any file by id" reader.
+function v_file_render_gone(int $modelId, string $reason): void
+{
+    snipeit_cache_delete('model_' . $modelId . '_files');
+    http_response_code(404);
+    header('Content-Type: text/html; charset=UTF-8');
+    header('Cache-Control: no-store');
+    $safeReason = htmlspecialchars($reason, ENT_QUOTES, 'UTF-8');
+    echo <<<HTML
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>File no longer available</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         background: #f6f7fb; color: #1f2937; margin: 0; padding: 2rem; }
+  .box { max-width: 480px; margin: 4rem auto; padding: 2rem;
+         background: #fff; border: 1px solid #d1d5db; border-radius: 8px;
+         text-align: center; }
+  h1 { font-size: 1.25rem; color: #111827; margin: 0 0 .5rem; }
+  p { color: #4b5563; margin: 0 0 1rem; }
+  .hint { font-size: .8125rem; color: #6b7280; }
+  a.back { display: inline-block; color: #0d6efd; text-decoration: none;
+           padding: .5rem 1rem; border: 1px solid #0d6efd; border-radius: 6px;
+           margin-top: .5rem; }
+  a.back:hover { background: #0d6efd; color: #fff; }
+</style>
+</head><body>
+<div class="box">
+  <h1>File no longer available</h1>
+  <p>{$safeReason}</p>
+  <p class="hint">The documentation list has been refreshed — go back and reload to see the current files.</p>
+  <a class="back" href="javascript:history.length>1?history.back():null;">Go back</a>
+</div>
+</body></html>
+HTML;
+}
+
 try {
     $files = get_model_files($modelId);
 } catch (Throwable $e) {
@@ -38,14 +78,21 @@ foreach ($files as $f) {
     }
 }
 if ($found === null) {
-    http_response_code(404);
-    echo 'File not found for this model.';
+    // Cache shows file doesn't belong to this model. Could be a stale
+    // cache (file added/removed since the v.php render). Bust and report.
+    v_file_render_gone($modelId, 'This file is no longer attached to its model.');
     exit;
 }
 
 try {
     [$contentType, $contentDisposition, $body] = fetch_model_file($modelId, $fileId);
 } catch (Throwable $e) {
+    if ((int)$e->getCode() === 404) {
+        // File was deleted on Snipe-IT after we cached the list. Bust the
+        // cache so the next v.php render picks up the change.
+        v_file_render_gone($modelId, 'This file has been removed from Snipe-IT.');
+        exit;
+    }
     http_response_code(502);
     echo 'Upstream fetch failed.';
     exit;

--- a/src/snipeit_client.php
+++ b/src/snipeit_client.php
@@ -49,6 +49,14 @@ function snipeit_cache_get(string $key, int $ttl)
     return is_array($decoded) ? $decoded : null;
 }
 
+function snipeit_cache_delete(string $key): void
+{
+    $path = snipeit_cache_path($key);
+    if (is_file($path)) {
+        @unlink($path);
+    }
+}
+
 function snipeit_cache_set(string $key, array $data): void
 {
     global $cacheDir;
@@ -520,7 +528,9 @@ function fetch_model_file(int $modelId, int $fileId): array
     curl_close($ch);
 
     if ($code !== 200) {
-        throw new Exception("Snipe-IT file fetch returned HTTP $code");
+        // Pass the upstream HTTP code through as the exception code so the
+        // caller can detect 404 (file deleted upstream) and bust caches.
+        throw new Exception("Snipe-IT file fetch returned HTTP $code", (int)$code);
     }
 
     $headerBlob = substr($response, 0, $headerSize);


### PR DESCRIPTION
Follow-up to #208/#210. When you delete/re-add a file in Snipe-IT, the cached model_files list still has the old IDs for up to 1h, leading to broken file links.

## Changes
- `snipeit_cache_delete($key)` added next to existing cache get/set
- `fetch_model_file()` now puts the upstream HTTP code into `Exception::getCode()` so callers can detect 404 vs other errors
- `v_file.php` busts `model_{id}_files` cache on either:
  1. Validation miss (file_id not in cached list)
  2. Upstream 404 (file deleted in Snipe-IT after we cached)
- Replaces the plain-text error with a friendly HTML page (back button)

After the bust, the next v.php load fetches a fresh file list — no manual cache clear needed.

## Test plan
- [ ] Browse /v/{tag} (warms model_files cache)
- [ ] Delete a file in Snipe-IT
- [ ] Click the now-stale file link — should see 'File no longer available' page
- [ ] Reload /v/{tag} — file list reflects current Snipe-IT state