### PR TITLE
Print Label: admin-only + nav link

### DIFF
--- a/public/ajax_asset_label_data.php
+++ b/public/ajax_asset_label_data.php
@@ -16,11 +16,9 @@ require_once SRC_PATH . '/snipeit_client.php';
 
 header('Content-Type: application/json');
 
-$isAdmin = !empty($currentUser['is_admin']);
-$isStaff = !empty($currentUser['is_staff']) || $isAdmin;
-if (!$isStaff) {
+if (empty($currentUser['is_admin'])) {
     http_response_code(403);
-    echo json_encode(['ok' => false, 'error' => 'Staff only.']);
+    echo json_encode(['ok' => false, 'error' => 'Admins only.']);
     exit;
 }
 

--- a/public/print_label.php
+++ b/public/print_label.php
@@ -18,9 +18,9 @@ require_once __DIR__ . '/../src/bootstrap.php';
 require_once SRC_PATH . '/auth.php';
 require_once SRC_PATH . '/layout.php';
 
-if (empty($currentUser['is_staff']) && empty($currentUser['is_admin'])) {
+if (empty($currentUser['is_admin'])) {
     http_response_code(403);
-    echo '<p>Staff only.</p>';
+    echo '<p>Admins only.</p>';
     exit;
 }
 
@@ -28,7 +28,7 @@ $labelType = $_GET['type'] ?? '';
 $labelType = in_array($labelType, ['generic', 'cable'], true) ? $labelType : '';
 
 layout_page_start([
-    'active'          => 'print_label',
+    'active'          => 'print_label.php',
     'title'           => 'Print Label',
     'pageHeaderTitle' => 'Print Label',
 ]);
@@ -101,5 +101,5 @@ layout_page_start([
 
 <?php
 layout_page_end([
-    'active' => 'print_label',
+    'active' => 'print_label.php',
 ]);

--- a/src/layout.php
+++ b/src/layout.php
@@ -195,6 +195,7 @@ if (!function_exists('layout_render_nav')) {
             ['type' => 'header', 'label' => 'Processing',  'staff' => true],
             ['href' => 'quick_checkout.php', 'label' => 'Quick Checkout', 'staff' => true, 'enabled' => $quickCheckoutEnabled, 'icon' => 'bi-box-arrow-right'],
             ['href' => 'quick_checkin.php',  'label' => 'Quick Checkin',  'staff' => true,  'icon' => 'bi-box-arrow-in-left'],
+            ['href' => 'print_label.php',    'label' => 'Print Label',    'staff' => false, 'admin_only' => true, 'icon' => 'bi-printer'],
 
             ['type' => 'header', 'label' => 'Admin',       'staff' => false, 'admin_only' => true],
             ['href' => 'activity_log.php',   'label' => 'Admin',          'staff' => false, 'admin_only' => true, 'icon' => 'bi-gear'],
@@ -285,6 +286,7 @@ if (!function_exists('layout_render_topbar')) {
             'reservations.php'       => 'Reservations',
             'quick_checkout.php'     => 'Quick Checkout',
             'quick_checkin.php'      => 'Quick Checkin',
+            'print_label.php'        => 'Print Label',
             'activity_log.php'       => 'Admin',
             'my_bookings.php'        => 'My Gear',
             'basket.php'             => 'Basket',
@@ -1072,6 +1074,7 @@ if (!function_exists('layout_page_title_map')) {
             'reservations.php'             => 'Reservations',
             'quick_checkout.php'           => 'Quick Checkout',
             'quick_checkin.php'            => 'Quick Checkin',
+            'print_label.php'              => 'Print Label',
             'activity_log.php'             => 'Admin',
             'my_bookings.php'              => 'My Gear',
             'basket.php'                   => 'Basket',


### PR DESCRIPTION
Follow-up to #214.

- Adds the **Print Label** entry to the staff/admin sidebar under Processing (admin-only)
- Restricts `print_label.php` and `ajax_asset_label_data.php` to admins (was staff-or-admin)
- Fixes the layout `active` key so the nav link highlights when on the page