### PR TITLE
print-label: support named-printer mode (forceRaw)

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -34,12 +34,22 @@
 
     function ensurePrinterConfig() {
         if (_printerConfig) return _printerConfig;
-        _printerConfig = qz.configs.create({
-            host: _cfg.printerHost,
-            port: _cfg.printerPort
-        }, {
-            encoding: 'UTF-8'
-        });
+        if (_cfg.printerName) {
+            // Named printer + bypass driver mode (per https://qz.io/docs/raw).
+            console.log('[print-label] config: named printer', _cfg.printerName, 'forceRaw=true');
+            _printerConfig = qz.configs.create(_cfg.printerName, {
+                forceRaw: true,
+                encoding: 'UTF-8'
+            });
+        } else {
+            console.log('[print-label] config: network', _cfg.printerHost + ':' + _cfg.printerPort);
+            _printerConfig = qz.configs.create({
+                host: _cfg.printerHost,
+                port: _cfg.printerPort
+            }, {
+                encoding: 'UTF-8'
+            });
+        }
         return _printerConfig;
     }
 

--- a/public/print_label.php
+++ b/public/print_label.php
@@ -87,8 +87,12 @@ layout_page_start([
   <script src="https://cdn.jsdelivr.net/npm/qz-tray@2/qz-tray.js"></script>
   <script src="assets/print-label.js"></script>
   <script>
+    // ?printer=Name uses a named printer with forceRaw:true (bypass driver
+    // mode). Otherwise default to direct network host:port.
+    var __printerName = new URLSearchParams(window.location.search).get('printer');
     PrintLabel.init({
       labelType: <?= json_encode($labelType, JSON_UNESCAPED_SLASHES) ?>,
+      printerName: __printerName || null,
       printerHost: '10.31.0.28',
       printerPort: 9100,
       certUrl: 'ajax_qz_cert.php',


### PR DESCRIPTION
Add `?printer=NAME` URL param. When set, uses `qz.configs.create(name, {forceRaw:true})` instead of the network host:port — per https://qz.io/docs/raw bypass driver mode. Lets us test whether the named-printer path works when the network path is stuck.