### PR TITLE
print-label: don't double-load qz-tray.js

### DIFF
--- a/public/print_label.php
+++ b/public/print_label.php
@@ -84,7 +84,15 @@ layout_page_start([
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/qz-tray@2/qz-tray.js"></script>
+  <?php
+    // layout.php already loads qz-tray.js when admin Settings has QZ Tray
+    // enabled. Loading it twice re-runs the IIFE and breaks the connection
+    // state (isActive() flips false). Only emit the tag when layout didn't.
+    $qzCfg = load_config()['qz_tray'] ?? [];
+    if (empty($qzCfg['enabled'])):
+  ?>
+    <script src="https://cdn.jsdelivr.net/npm/qz-tray@2/qz-tray.js"></script>
+  <?php endif; ?>
   <script src="assets/print-label.js"></script>
   <script>
     // ?printer=Name uses a named printer with forceRaw:true (bypass driver


### PR DESCRIPTION
Root cause of the persistent 'no connection established' error. layout.php already loads qz-tray.js when QZ Tray is enabled, and print_label.php was loading it again — the second IIFE pass breaks the qz global state while the WS itself stays open and healthy (we can even see the keepalive pings continuing in the WS Messages tab). Only emit the script tag from print_label.php as a fallback when layout didn't.