### PR TITLE
print-label: poll for qz library to load

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -20,16 +20,24 @@
 
     function init(opts) {
         _cfg = opts;
-        if (typeof qz === 'undefined') {
-            setStatus('error', 'QZ Tray library failed to load.');
-            return;
+        // layout.php loads qz-tray.js from layout_footer, which runs AFTER
+        // this page's body scripts. So qz may not exist yet — poll briefly.
+        var waited = 0;
+        function whenReady() {
+            if (typeof qz !== 'undefined') {
+                _printerConfig = null;
+                wireUI();
+                connectAndPrepare();
+                return;
+            }
+            if (waited > 5000) {
+                setStatus('error', 'QZ Tray library failed to load.');
+                return;
+            }
+            waited += 50;
+            setTimeout(whenReady, 50);
         }
-        // Defer qz.configs.create until after the websocket is fully active —
-        // creating it at init had no functional effect but also no benefit.
-        _printerConfig = null;
-
-        wireUI();
-        connectAndPrepare();
+        whenReady();
     }
 
     function ensurePrinterConfig() {


### PR DESCRIPTION
Fix the 'QZ Tray library failed to load' error introduced by the dedupe in #220. layout.php emits qz-tray.js from layout_footer which runs after this page's body content, so my init was checking for qz before it loaded. Poll for up to 5s instead of failing immediately.