### PR TITLE
print-label: version the fontsLoaded sessionStorage key

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -12,7 +12,9 @@
 (function () {
     'use strict';
 
-    var FONTS_SESSION_KEY = 'printLabel.fontsLoaded';
+    // Bump this when the fonts file or its drive letter changes so old
+    // sessionStorage flags from prior deploys don't block a needed re-upload.
+    var FONTS_SESSION_KEY = 'printLabel.fontsLoaded.r1';
 
     var _cfg = null;
     var _printerConfig = null;


### PR DESCRIPTION
Auto-recover after a fonts-file or drive change. Old flag from a previous deploy was blocking the R: upload that the current template needs.