### PR TITLE
Print Label: QR Only template

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -221,6 +221,9 @@
         if (labelType === 'cable') {
             return buildCableWrapZpl(asset);
         }
+        if (labelType === 'qronly') {
+            return buildQrOnlyZpl(asset);
+        }
         return buildGenericZpl(asset);
     }
 
@@ -261,6 +264,37 @@
     function buildCableWrapZpl(asset) {
         // TODO: bespoke 1"×2.25" wrap layout (^PW203^LL457 portrait, smaller text)
         return buildGenericZpl(asset);
+    }
+
+    /**
+     * QR-only label (2" × 1", 203 dpi → 406 × 203 dots).
+     * Three QR codes of decreasing magnification (5/3/2) across the top
+     * with the asset_tag under each. No description, no Code 128.
+     */
+    function buildQrOnlyZpl(asset) {
+        var tag = sanitizeZpl(asset.asset_tag);
+        return [
+            '^XA~TA000~JSN^LT5^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA^CWL,r:SWISS^XZ',
+            '^XA^CWK,r:JBM_RG^XZ',
+            '^XA',
+            '^CI28',
+            '^BY2,2',
+            '^ARN,',
+            '^FT10,176^AKN,36^FB126,1,0,C^FD' + tag + '\\&^FS',
+            '^FT200,112^AKN,22^FB74,1,0,C^FD' + tag + '\\&^FS',
+            '^FT340,82^AKN,16^FB52,1,0,C^FD' + tag + '\\&^FS',
+            '^FO10,5',
+            '^BQN,2,5',
+            '^FDLA,https://wrapit.us/v/' + tag + '^FS',
+            '^FO200,5',
+            '^BQN,2,3',
+            '^FDLA,https://wrapit.us/v/' + tag + '^FS',
+            '^FO340,5',
+            '^BQN,2,2',
+            '^FDLA,https://wrapit.us/v/' + tag + '^FS',
+            '^PQ1^XZ'
+        ].join('\n');
     }
 
     /**

--- a/public/print_label.php
+++ b/public/print_label.php
@@ -25,7 +25,7 @@ if (empty($currentUser['is_admin'])) {
 }
 
 $labelType = $_GET['type'] ?? '';
-$labelType = in_array($labelType, ['generic', 'cable'], true) ? $labelType : '';
+$labelType = in_array($labelType, ['generic', 'qronly', 'cable'], true) ? $labelType : '';
 
 layout_page_start([
     'active'          => 'print_label.php',
@@ -41,6 +41,7 @@ layout_page_start([
       <p class="text-muted mb-3">The label type is locked for the session. Reload the page to switch.</p>
       <div class="d-flex flex-wrap gap-2">
         <a class="btn btn-primary" href="print_label.php?type=generic">Generic (2&Prime; &times; 1&Prime;)</a>
+        <a class="btn btn-outline-primary" href="print_label.php?type=qronly">QR Only (2&Prime; &times; 1&Prime;)</a>
         <a class="btn btn-outline-primary" href="print_label.php?type=cable">Cable wrap (1&Prime; &times; 2.25&Prime;)</a>
       </div>
     </div>
@@ -51,7 +52,7 @@ layout_page_start([
       <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
         <div>
           <span class="text-muted small">Label type</span>
-          <strong class="ms-1"><?= h($labelType === 'cable' ? 'Cable wrap (1″ × 2.25″)' : 'Generic (2″ × 1″)') ?></strong>
+          <strong class="ms-1"><?= h($labelType === 'cable' ? 'Cable wrap (1″ × 2.25″)' : ($labelType === 'qronly' ? 'QR Only (2″ × 1″)' : 'Generic (2″ × 1″)')) ?></strong>
           <a class="ms-3 small" href="print_label.php">switch</a>
         </div>
         <div id="printer-status" class="small text-muted">


### PR DESCRIPTION
New 'QR Only' label type — three QR codes of decreasing magnification (5/3/2) across a 2x1 label with the asset_tag printed under each, no description and no Code 128. Sits alongside Generic and the still-placeholder Cable wrap.