### PR TITLE
Print Label: Barcode Only template

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -224,6 +224,9 @@
         if (labelType === 'qronly') {
             return buildQrOnlyZpl(asset);
         }
+        if (labelType === 'barcode') {
+            return buildBarcodeOnlyZpl(asset);
+        }
         return buildGenericZpl(asset);
     }
 
@@ -323,6 +326,28 @@
     function buildCableWrapZpl(asset) {
         // TODO: bespoke 1"×2.25" wrap layout (^PW203^LL457 portrait, smaller text)
         return buildGenericZpl(asset);
+    }
+
+    /**
+     * Barcode-only label (2" × 1", 203 dpi → 406 × 203 dots).
+     * Two Code 128 barcodes: a large horizontal one with human-readable
+     * digits centered, plus a small vertical one at the right edge.
+     */
+    function buildBarcodeOnlyZpl(asset) {
+        var tag = sanitizeZpl(asset.asset_tag);
+        return [
+            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA^CWL,r:SWISS^XZ',
+            '^XA^CWK,r:JBM_RG^XZ',
+            '^XA',
+            '^CI28',
+            '^BY3,2,90',
+            '^FT60,130^BCN^FD' + tag + '^FS',
+            '^BY2,2,20',
+            '^FT380,180^BCB^FD' + tag + '^FS',
+            '^FT0,194^A0N,12,13^FB350,1,0,C^FDProperty of Southern Adventist University-SVAD\\&^FS',
+            '^PQ1^XZ'
+        ].join('\n');
     }
 
     /**

--- a/public/print_label.php
+++ b/public/print_label.php
@@ -25,7 +25,7 @@ if (empty($currentUser['is_admin'])) {
 }
 
 $labelType = $_GET['type'] ?? '';
-$labelType = in_array($labelType, ['generic', 'qronly', 'cable'], true) ? $labelType : '';
+$labelType = in_array($labelType, ['generic', 'qronly', 'barcode', 'cable'], true) ? $labelType : '';
 
 layout_page_start([
     'active'          => 'print_label.php',
@@ -42,6 +42,7 @@ layout_page_start([
       <div class="d-flex flex-wrap gap-2">
         <a class="btn btn-primary" href="print_label.php?type=generic">Generic (2&Prime; &times; 1&Prime;)</a>
         <a class="btn btn-outline-primary" href="print_label.php?type=qronly">QR Only (2&Prime; &times; 1&Prime;)</a>
+        <a class="btn btn-outline-primary" href="print_label.php?type=barcode">Barcode Only (2&Prime; &times; 1&Prime;)</a>
         <a class="btn btn-outline-primary" href="print_label.php?type=cable">Cable wrap (1&Prime; &times; 2.25&Prime;)</a>
       </div>
     </div>
@@ -52,7 +53,12 @@ layout_page_start([
       <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
         <div>
           <span class="text-muted small">Label type</span>
-          <strong class="ms-1"><?= h($labelType === 'cable' ? 'Cable wrap (1″ × 2.25″)' : ($labelType === 'qronly' ? 'QR Only (2″ × 1″)' : 'Generic (2″ × 1″)')) ?></strong>
+          <strong class="ms-1"><?= h(
+              $labelType === 'cable'   ? 'Cable wrap (1″ × 2.25″)'
+            : ($labelType === 'qronly'  ? 'QR Only (2″ × 1″)'
+            : ($labelType === 'barcode' ? 'Barcode Only (2″ × 1″)'
+            : 'Generic (2″ × 1″)'))
+          ) ?></strong>
           <a class="ms-3 small" href="print_label.php">switch</a>
         </div>
         <div id="printer-status" class="small text-muted">


### PR DESCRIPTION
New 'Barcode Only' label type for assets where the QR isn't useful. Two Code 128 barcodes (one horizontal with human-readable digits, one vertical at the right edge) and the standard property footer.