### PR TITLE
Print Label: preview pane via Labelary

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -29,6 +29,7 @@
             if (typeof qz !== 'undefined') {
                 _printerConfig = null;
                 wireUI();
+                renderPreview(sampleAsset());
                 connectAndPrepare();
                 return;
             }
@@ -61,6 +62,40 @@
             });
         }
         return _printerConfig;
+    }
+
+    /**
+     * Render the current label type to an <img> via the Labelary API so
+     * the operator can see what they're printing. Direct GET with the
+     * URL-encoded ZPL in the path; no fetch / blob handling needed.
+     */
+    function renderPreview(asset) {
+        var el = document.getElementById('label-preview');
+        if (!el) return;
+        var zpl;
+        try {
+            zpl = buildLabelZpl(asset, _cfg.labelType);
+        } catch (e) {
+            el.innerHTML = '<span class="text-danger small">Preview failed: ' + escapeHtml(e.message || e) + '</span>';
+            return;
+        }
+        var dims = _cfg.labelType === 'cable' ? '1x2.25' : '2x1';
+        var url = 'https://api.labelary.com/v1/printers/8dpmm/labels/'
+                + dims + '/0/' + encodeURIComponent(zpl);
+        el.innerHTML = '<img src="' + url + '" alt="label preview" '
+                     + 'style="max-width:100%; max-height:300px;" '
+                     + 'onerror="this.replaceWith(Object.assign(document.createElement(\'span\'),'
+                     + '{className:\'text-muted small\', textContent:\'(preview unavailable)\'}));">';
+    }
+
+    function sampleAsset() {
+        return {
+            asset_tag: '1234',
+            asset_name: '',
+            model_name: 'Sample Asset Description',
+            description: 'Sample Asset Description',
+            serial: ''
+        };
     }
 
     function wireUI() {

--- a/public/print_label.php
+++ b/public/print_label.php
@@ -84,6 +84,15 @@ layout_page_start([
     </div>
   </div>
 
+  <div class="card mb-3">
+    <div class="card-body">
+      <h6 class="card-title text-muted mb-2">Preview</h6>
+      <div id="label-preview" class="d-flex align-items-center justify-content-center" style="min-height:160px; background:#f6f7fb; border:1px solid #dee2e6; border-radius:6px; padding:8px;">
+        <span class="text-muted small">— rendering sample… —</span>
+      </div>
+    </div>
+  </div>
+
   <div class="card">
     <div class="card-body">
       <h6 class="card-title text-muted">Last printed</h6>


### PR DESCRIPTION
Render a sample of the current label style under the scan input so the operator can see at a glance which template they're set to print. Direct GET to Labelary as the <img> src; no fetch + blob handling needed. One-shot at page load, not per print.