### PR TITLE
preview: improve contrast of label vs. background

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -115,7 +115,8 @@
             .then(function (blob) {
                 var url = URL.createObjectURL(blob);
                 el.innerHTML = '<img src="' + url + '" alt="label preview" '
-                             + 'style="max-width:100%; max-height:300px;">';
+                             + 'style="max-width:100%; max-height:300px; '
+                             + 'box-shadow:0 4px 12px rgba(0,0,0,0.5); border-radius:2px;">';
             })
             .catch(function (err) {
                 console.error('[print-label] preview failed:', err);

--- a/public/print_label.php
+++ b/public/print_label.php
@@ -87,7 +87,7 @@ layout_page_start([
   <div class="card mb-3">
     <div class="card-body">
       <h6 class="card-title text-muted mb-2">Preview</h6>
-      <div id="label-preview" class="d-flex align-items-center justify-content-center" style="min-height:160px; background:#f6f7fb; border:1px solid #dee2e6; border-radius:6px; padding:8px;">
+      <div id="label-preview" class="d-flex align-items-center justify-content-center" style="min-height:160px; background:#2a2a2a; border:1px solid #444; border-radius:6px; padding:16px;">
         <span class="text-muted small">— rendering sample… —</span>
       </div>
     </div>


### PR DESCRIPTION
Darken the preview area background to #2a2a2a and add a drop shadow on the rendered image so the white label stands out clearly on the dark theme.