### PR TITLE
Revert: ^MNY + ^MMK back to ^MNW

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -316,7 +316,7 @@
             ? '^FT110,96^AKN,14^FB320,1,0,C^FDS/N: ' + serial + '\\&^FS'
             : '';
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNY^MTT^MMK^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',
@@ -413,7 +413,7 @@
     function buildBarcodeOnlyZpl(asset) {
         var tag = sanitizeZpl(asset.asset_tag);
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNY^MTT^MMK^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',
@@ -436,7 +436,7 @@
     function buildQrOnlyZpl(asset) {
         var tag = sanitizeZpl(asset.asset_tag);
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNY^MTT^MMK^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',


### PR DESCRIPTION
Per print test, the kiosk-mode + non-continuous web-sensing change didn't behave as hoped on the RZ400 (cutter attachment is non-functional). Reverting the header to its original form across all three templates.