### PR TITLE
Revert ^MMP

### DIFF
--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -316,7 +316,7 @@
             ? '^FT110,96^AKN,14^FB320,1,0,C^FDS/N: ' + serial + '\\&^FS'
             : '';
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^MMP^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',
@@ -413,7 +413,7 @@
     function buildBarcodeOnlyZpl(asset) {
         var tag = sanitizeZpl(asset.asset_tag);
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^MMP^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',
@@ -436,7 +436,7 @@
     function buildQrOnlyZpl(asset) {
         var tag = sanitizeZpl(asset.asset_tag);
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^MMP^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',


### PR DESCRIPTION
Peeler sensor on this RZ400 is missing/non-functional, so peel-off mode just hangs. Reverting back to default tear-off behavior.