### PR TITLE
Print Label: configurable ^LT (top) offset

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -186,6 +186,7 @@ return [
         'private_key_path'     => '',       // Absolute path to private key PEM (outside web root)
         'paper_width'          => 42,       // Chars per line: 42 for 80mm, 30 for 58mm
         'auto_print_checkout'  => false,    // Auto-print receipt on successful checkout
+        'label_top_offset'     => 0,        // ZPL ^LT offset in dots, range -120 to 120. Shifts every label vertically to compensate for stock-alignment drift. Positive = content moves down, negative = up.
     ],
 
     'smtp' => [

--- a/public/assets/print-label.js
+++ b/public/assets/print-label.js
@@ -309,6 +309,7 @@
      */
     function buildGenericZpl(asset) {
         var tag = sanitizeZpl(asset.asset_tag);
+        var lt = String(_cfg.labelTopOffset || 0);
         var description = sanitizeZpl(asset.description || asset.asset_name || asset.model_name || '');
         var serial = sanitizeZpl(asset.serial || '');
         var descField = buildDescriptionField(description);
@@ -316,7 +317,7 @@
             ? '^FT110,96^AKN,14^FB320,1,0,C^FDS/N: ' + serial + '\\&^FS'
             : '';
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT' + lt + '^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',
@@ -412,8 +413,9 @@
      */
     function buildBarcodeOnlyZpl(asset) {
         var tag = sanitizeZpl(asset.asset_tag);
+        var lt = String(_cfg.labelTopOffset || 0);
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT' + lt + '^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',
@@ -435,8 +437,9 @@
      */
     function buildQrOnlyZpl(asset) {
         var tag = sanitizeZpl(asset.asset_tag);
+        var lt = String(_cfg.labelTopOffset || 0);
         return [
-            '^XA~TA000~JSN^LT0^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
+            '^XA~TA000~JSN^LT' + lt + '^LS5^MNW^MTT^PON^PMN^LH0,0^JMA^PR3,3~SD25^JUS^LRN^CI28^PW406^LL203^XZ',
             '^XA^CWL,r:SWISS^XZ',
             '^XA^CWK,r:JBM_RG^XZ',
             '^XA',

--- a/public/print_label.php
+++ b/public/print_label.php
@@ -133,7 +133,8 @@ layout_page_start([
       certUrl: 'ajax_qz_cert.php',
       signUrl: 'ajax_qz_sign.php',
       fontsUrl: 'assets/label_fonts.zpl',
-      assetLookupUrl: 'ajax_asset_label_data.php'
+      assetLookupUrl: 'ajax_asset_label_data.php',
+      labelTopOffset: <?= (int)($qzCfg['label_top_offset'] ?? 0) ?>
     });
   </script>
 <?php endif; ?>

--- a/public/settings.php
+++ b/public/settings.php
@@ -484,6 +484,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $pwRaw = $post('qz_paper_width', $qzTray['paper_width'] ?? 42);
     $qzTray['paper_width']         = in_array((int)$pwRaw, [30, 42], true) ? (int)$pwRaw : 42;
     $qzTray['auto_print_checkout'] = isset($_POST['qz_auto_print']);
+    $offsetRaw = $post('qz_label_top_offset', $qzTray['label_top_offset'] ?? 0);
+    $offset    = (int)$offsetRaw;
+    if ($offset < -120) { $offset = -120; }
+    if ($offset >  120) { $offset =  120; }
+    $qzTray['label_top_offset']    = $offset;
 
     // Notifications
     $notifications = $config['notifications'] ?? [];
@@ -1307,6 +1312,11 @@ layout_page_start([
                                     <option value="42" <?= $qzPaperWidth === 42 ? 'selected' : '' ?>>80mm (42 chars)</option>
                                     <option value="30" <?= $qzPaperWidth === 30 ? 'selected' : '' ?>>58mm (30 chars)</option>
                                 </select>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">Label printer offset (dots)</label>
+                                <input type="number" name="qz_label_top_offset" class="form-control" min="-120" max="120" step="1" value="<?= (int)$cfg(['qz_tray', 'label_top_offset'], 0) ?>">
+                                <div class="form-text">Shifts every label vertically to compensate for stock-alignment drift. Positive = content down, negative = up. Range −120 to 120 dots.</div>
                             </div>
                             <div class="col-md-6">
                                 <label class="form-label">Certificate path (PEM)</label>


### PR DESCRIPTION
Admin → Settings → QZ Tray gets a new 'Label printer offset (dots)' field. Persists in `qz_tray.label_top_offset`, clamped server-side to [-120, 120]. Substitutes for the previously-hardcoded `^LT0` in Generic, QR Only, and Barcode Only label templates so the operator can compensate for stock drift without code edits.