### PR TITLE
Fix CSS hygiene: replace #fff literal in .catalogue-basket-count

### DIFF
--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -1046,7 +1046,7 @@ button.app-topbar-crumb--link {
 
 .catalogue-basket-count {
     background: var(--status-info);
-    color: #fff;
+    color: var(--white);
     font-size: 10px;
     font-weight: 700;
     min-width: 18px;


### PR DESCRIPTION
## Summary
- Replaces hardcoded `color: #fff` in `.catalogue-basket-count` with `color: var(--white)`, fixing the `check_css_hygiene.sh` failure reported in #243.

## Test plan
- [ ] Run `bash scripts/check_css_hygiene.sh` — should exit clean
- [ ] Visually confirm basket count badge still renders white text on the catalogue page

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)